### PR TITLE
Split repository's CI workflow into functional parts.

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,50 @@
+name: Lint Python code
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/lint-python.yml'
+      - 'compilesketches/**.py'
+
+  push:
+    paths:
+      - '.github/workflows/lint-python.yml'
+      - 'compilesketches/**.py'
+
+  # Scheduled trigger checks for workflow failures resulting from updates to the linting tools
+  schedule:
+    # run every Tuesday at 3 AM UTC
+    - cron: "0 3 * * 2"
+
+  # workflow_dispatch event allows the workflow to be triggered manually
+  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+
+  # repository_dispatch event allows the workflow to be triggered via the GitHub API
+  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.8.5'
+
+      - name: Install flake8
+        run: |
+          python -m pip install --upgrade pip
+          pip install --quiet flake8
+          pip install --quiet pep8-naming
+
+      - name: Lint with flake8
+        env:
+          PYTHON_PROJECT_PATH: ${GITHUB_WORKSPACE}/compilesketches
+        run: |
+          flake8 --config "${{ env.PYTHON_PROJECT_PATH }}/.flake8" --show-source "${{ env.PYTHON_PROJECT_PATH }}"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,15 +1,29 @@
-name: libraries/compile-examples workflow
+name: Test Python code
 
 on:
   pull_request:
     paths:
-      - '.github/workflows/libraries_compile-examples.yml'
-      - 'libraries/compile-examples/**'
+      - '.github/workflows/test-python.yml'
+      - 'compilesketches/**'
 
   push:
     paths:
-      - '.github/workflows/libraries_compile-examples.yml'
-      - 'libraries/compile-examples/**'
+      - '.github/workflows/test-python.yml'
+      - 'compilesketches/**'
+
+  # The actions/setup-python action will periodically break the workflow by dropping the Python version we have pinned
+  # Better to catch that before it causes confusion for a contributor
+  schedule:
+    # run every Tuesday at 3 AM UTC
+    - cron: "0 3 * * 2"
+
+  # workflow_dispatch event allows the workflow to be triggered manually
+  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+
+  # repository_dispatch event allows the workflow to be triggered via the GitHub API
+  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
 
 jobs:
   test:
@@ -32,12 +46,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --requirement "${{ env.PYTHON_PROJECT_TESTS_PATH }}/requirements.txt"
-
-      - name: Lint with flake8
-        run: |
-          pip install --quiet flake8
-          pip install --quiet pep8-naming
-          flake8 --config "${{ env.PYTHON_PROJECT_PATH }}/.flake8" --show-source "${{ env.PYTHON_PROJECT_PATH }}"
 
       - name: Run Python unit tests and report code coverage
         run: |


### PR DESCRIPTION
In the experimental repository the action was migrated from, the system was to have a single workflow for each action hosted in the repository.

Although it is a sensible approach in that context, it meant combining things that are only loosely related into a single workflow. Now that the action has a dedicated repository, it makes sense to split it into multiple workflows:
* Testing
* Linting