### PR TITLE
Use appropriate default value for sketches-report-path input

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Path in which to save a JSON formatted file containing data from the sketch comp
 
 This report is used by the [`arduino/report-size-deltas`](https://github.com/arduino/report-size-deltas) and [`arduino/report-size-trends`](https://github.com/arduino/report-size-trends) actions.
 
-**Default**: `"size-deltas-reports"`
+**Default**: `"sketches-reports"`
 
 ### `github-token`
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: false
   sketches-report-path:
     description: 'Path in which to save a JSON formatted file containing data from the sketch compilations'
-    default: 'size-deltas-reports'
+    default: 'sketches-reports'
   github-token:
     description: 'GitHub access token used to get information from the GitHub API. Only needed if you are using the deltas report feature in a private repository.'
     default: ''


### PR DESCRIPTION
In the time since it was first conceived, the use of the report file created by the compile-sketches action has been expanded from only being a way to pass memory usage change data to the `arduino/report-size-deltas` action to a general purpose report of data generated from the sketch compilations, including:

- Non-deltas size data consumed by `arduino/report-size-trends`
- Compilation status for each sketch/board combination
- Compiler warning count

It's possible additional information will be added to the report over time.

For this reason, the previous default `size-deltas-reports` was no longer appropriate and might be the source of confusion.

Unfortunately, this is a breaking change for people who:

- Did not specify a value to the `sketches-report-path` input and,
- have an additional step in their workflow (e.g., `actions/upload-artifact`) that relies on the sketches reports being located under the folder resulting from the previous default