### PR TITLE
Handle "N/A" warning count data when generating summary report

### DIFF
--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -1356,14 +1356,22 @@ class CompileSketches:
                 if (
                     summary_report_minimum is None
                     or summary_report_minimum == self.not_applicable_indicator
-                    or summary_report_minimum > sketch_report_delta
+                ):
+                    summary_report_minimum = sketch_report_delta
+                elif (
+                    sketch_report_delta != self.not_applicable_indicator
+                    and summary_report_minimum > sketch_report_delta
                 ):
                     summary_report_minimum = sketch_report_delta
 
                 if (
                     summary_report_maximum is None
                     or summary_report_maximum == self.not_applicable_indicator
-                    or summary_report_maximum < sketch_report_delta
+                ):
+                    summary_report_maximum = sketch_report_delta
+                elif (
+                    sketch_report_delta != self.not_applicable_indicator
+                    and summary_report_maximum < sketch_report_delta
                 ):
                     summary_report_maximum = sketch_report_delta
 

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -2386,6 +2386,127 @@ def test_get_warnings_summary_report():
         expected_warnings_summary_report
     )
 
+    sketch_report_list = [
+        {
+            compilesketches.CompileSketches.ReportKeys.warnings: {
+                compilesketches.CompileSketches.ReportKeys.delta: {
+                    compilesketches.CompileSketches.ReportKeys.absolute: 3
+                }
+            },
+        },
+        {
+            compilesketches.CompileSketches.ReportKeys.warnings: {
+                compilesketches.CompileSketches.ReportKeys.delta: {
+                    compilesketches.CompileSketches.ReportKeys.absolute: 42
+                }
+            }
+        }
+    ]
+
+    expected_warnings_summary_report = {
+        compilesketches.CompileSketches.ReportKeys.delta: {
+            compilesketches.CompileSketches.ReportKeys.absolute: {
+                compilesketches.CompileSketches.ReportKeys.minimum: 3,
+                compilesketches.CompileSketches.ReportKeys.maximum: 42
+            }
+        }
+    }
+
+    assert compile_sketches.get_warnings_summary_report(sketch_report_list=sketch_report_list) == (
+        expected_warnings_summary_report
+    )
+
+    # N/As
+    sketch_report_list = [
+        {
+            compilesketches.CompileSketches.ReportKeys.warnings: {
+                compilesketches.CompileSketches.ReportKeys.delta: {
+                    compilesketches.CompileSketches.ReportKeys.absolute: compile_sketches.not_applicable_indicator
+                }
+            },
+        },
+        {
+            compilesketches.CompileSketches.ReportKeys.warnings: {
+                compilesketches.CompileSketches.ReportKeys.delta: {
+                    compilesketches.CompileSketches.ReportKeys.absolute: 3
+                }
+            }
+        }
+    ]
+
+    expected_warnings_summary_report = {
+        compilesketches.CompileSketches.ReportKeys.delta: {
+            compilesketches.CompileSketches.ReportKeys.absolute: {
+                compilesketches.CompileSketches.ReportKeys.minimum: 3,
+                compilesketches.CompileSketches.ReportKeys.maximum: 3
+            }
+        }
+    }
+
+    assert compile_sketches.get_warnings_summary_report(sketch_report_list=sketch_report_list) == (
+        expected_warnings_summary_report
+    )
+
+    sketch_report_list = [
+        {
+            compilesketches.CompileSketches.ReportKeys.warnings: {
+                compilesketches.CompileSketches.ReportKeys.delta: {
+                    compilesketches.CompileSketches.ReportKeys.absolute: 42
+                }
+            },
+        },
+        {
+            compilesketches.CompileSketches.ReportKeys.warnings: {
+                compilesketches.CompileSketches.ReportKeys.delta: {
+                    compilesketches.CompileSketches.ReportKeys.absolute: compile_sketches.not_applicable_indicator
+                }
+            }
+        }
+    ]
+
+    expected_warnings_summary_report = {
+        compilesketches.CompileSketches.ReportKeys.delta: {
+            compilesketches.CompileSketches.ReportKeys.absolute: {
+                compilesketches.CompileSketches.ReportKeys.minimum: 42,
+                compilesketches.CompileSketches.ReportKeys.maximum: 42
+            }
+        }
+    }
+
+    assert compile_sketches.get_warnings_summary_report(sketch_report_list=sketch_report_list) == (
+        expected_warnings_summary_report
+    )
+
+    sketch_report_list = [
+        {
+            compilesketches.CompileSketches.ReportKeys.warnings: {
+                compilesketches.CompileSketches.ReportKeys.delta: {
+                    compilesketches.CompileSketches.ReportKeys.absolute: compile_sketches.not_applicable_indicator
+                }
+            },
+        },
+        {
+            compilesketches.CompileSketches.ReportKeys.warnings: {
+                compilesketches.CompileSketches.ReportKeys.delta: {
+                    compilesketches.CompileSketches.ReportKeys.absolute: compile_sketches.not_applicable_indicator
+                }
+            }
+        }
+    ]
+
+    expected_warnings_summary_report = {
+        compilesketches.CompileSketches.ReportKeys.delta: {
+            compilesketches.CompileSketches.ReportKeys.absolute: {
+                compilesketches.CompileSketches.ReportKeys.minimum: compile_sketches.not_applicable_indicator,
+                compilesketches.CompileSketches.ReportKeys.maximum: compile_sketches.not_applicable_indicator
+            }
+        }
+    }
+
+    assert compile_sketches.get_warnings_summary_report(sketch_report_list=sketch_report_list) == (
+        expected_warnings_summary_report
+    )
+
     # Test with deltas disabled
     sketch_report_list = [
         {


### PR DESCRIPTION
When it is not possible to compile the sketch at the deltas base ref, the warning count delta is recorded as "N/A".
Previously, the summary report generation code did not handle this case correctly, which resulted in failing with an
error:
```
TypeError: '>' not supported between instances of 'int' and 'str'
```