### PR TITLE
Use Python 3.8.6 in CI and Docker container

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.6'
 
       - name: Install flake8
         run: |

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.6'
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.5
+FROM python:3.8.6
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY compilesketches /compilesketches


### PR DESCRIPTION
The 	`actions/setup-python` action used to install Python for use in the CI workflows no longer offers Python 3.8.5,
which [caused the CI to fail](https://github.com/arduino/compile-sketches/actions/runs/303557558).

The action should use the same version of Python it's tested with, so I have also updated the action's Docker image to
`python:3.8.6`.