### PR TITLE
Add CI workflow to validate action.yml against JSON schema

### DIFF
--- a/.github/workflows/validate-action_yml.yml
+++ b/.github/workflows/validate-action_yml.yml
@@ -1,0 +1,47 @@
+name: Validate action.yml
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/validate-action_yml.yml"
+      - "action.yml"
+  push:
+    paths:
+      - ".github/workflows/validate-action_yml.yml"
+      - "action.yml"
+  # Scheduled trigger to catch workflow failure resulting from changes to the JSON schema
+  schedule:
+    # run every Tuesday at 3 AM UTC
+    - cron: "0 3 * * 2"
+  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    env:
+      JSON_SCHEMA_FOLDER: etc/github-action-json-schema
+      JSON_SCHEMA_FILENAME: github-action.json
+
+    steps:
+      - name: Checkout local repository
+        uses: actions/checkout@v2
+
+      # See: https://github.com/carlosperate/download-file-action/blob/master/README.md
+      - name: Download JSON schema for action.yml
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-action.json
+          file-url: https://json.schemastore.org/github-action
+          location: ${{ env.JSON_SCHEMA_FOLDER }}
+          file-name: ${{ env.JSON_SCHEMA_FILENAME }}
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      # See: https://github.com/ajv-validator/ajv-cli/blob/master/README.md
+      - name: Validate action.yml
+        run: ajv -s "${{ env.JSON_SCHEMA_FOLDER }}/${{ env.JSON_SCHEMA_FILENAME }}" -d action.yml

--- a/action.yml
+++ b/action.yml
@@ -4,33 +4,43 @@ inputs:
   cli-version:
     description: 'Version of Arduino CLI to use when building'
     default: 'latest'
+    required: true
   fqbn:
     description: 'Full qualified board name, with Boards Manager URL if needed'
     default: 'arduino:avr:uno'
+    required: true
   libraries:
     description: 'YAML-format list of library dependencies to install'
     default: '- source-path: ./'
+    required: true
   platforms:
     description: 'YAML-format list of platform dependencies to install'
     default: ''
+    required: true
   sketch-paths:
     description: 'YAML-format list of paths containing sketches to compile.'
     default: '- examples'
+    required: true
   verbose:
     description: 'Set to true to show verbose output in the log'
-    default: false
+    default: 'false'
+    required: true
   sketches-report-path:
     description: 'Path in which to save a JSON formatted file containing data from the sketch compilations'
     default: 'sketches-reports'
+    required: true
   github-token:
     description: 'GitHub access token used to get information from the GitHub API. Only needed if you are using the deltas report feature in a private repository.'
     default: ''
+    required: true
   enable-deltas-report:
     description: 'Set to true to cause the action to determine the change in memory usage and compiler warnings of the compiled sketches between the head and base refs of a PR and the immediate parent commit of a push'
-    default: false
+    default: 'false'
+    required: true
   enable-warnings-report:
     description: 'Set to true to cause the action to record the compiler warning count for each sketch compilation in the sketches report'
-    default: false
+    default: 'false'
+    required: true
 
 runs:
   using: 'docker'


### PR DESCRIPTION
This uses [a community-generated schema](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-action.json) (because there is no official one), but the schema is well done and actively maintained.

Demonstration of failed validation: https://github.com/arduino/compile-sketches/runs/1304026010