### PR TITLE
Give Python virtual environment access to system site-packages directory

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/test-integration.yml'
       - '.github/workflows/testdata'
       - 'action.yml'
+      - 'action-setup.sh'
       - 'compilesketches/**'
 
   push:
@@ -13,6 +14,7 @@ on:
       - '.github/workflows/test-integration.yml'
       - '.github/workflows/testdata'
       - 'action.yml'
+      - 'action-setup.sh'
       - 'compilesketches/**'
 
 env:

--- a/action-setup.sh
+++ b/action-setup.sh
@@ -29,7 +29,7 @@ sudo apt-get install --yes python3-setuptools > /dev/null
 sudo apt-get install --yes python${PYTHON_PACKAGE_VERSION}-venv > /dev/null
 
 # Create Python virtual environment
-"$PYTHON_COMMAND" -m venv "$PYTHON_VENV_PATH"
+"$PYTHON_COMMAND" -m venv --system-site-packages "$PYTHON_VENV_PATH"
 
 # Activate Python virtual environment
 # shellcheck source=/dev/null


### PR DESCRIPTION
Use the `venv --system-site-packages` flag when creating the Python virtual environment the action's script runs in to allow users to install Python package dependencies of their sketch's boards platform dependencies.

The immediate need for this is that the ESP32 boards platform has a dependency on the `pyserial` Python package. This results in the compilation for boards of that platform failing:
```
  Traceback (most recent call last):
    File "/home/runner/.arduino15/packages/esp32/tools/esptool_py/2.6.1/esptool.py", line 37, in <module>
      import serial
  ModuleNotFoundError: No module named 'serial'
  Error during build: exit status 1
```
Prior to this change, this error would occur even if the user installed the `pyserial` package in a previous workflow step.

The alternative would be to always install this specific package in the setup script, but allowing the user to install arbitrary Python package dependencies makes the action more flexible:
```yaml
- run: pip3 install pyserial
- uses: arduino/compile-sketches@main
  with:
    platforms: |
      - name: esp32:esp32
        source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
    fqbn: esp32:esp32:esp32
```

The cons:
- Increased complexity of workflows compiling for ESP32 platform boards due to the need for the package installation step.
- Risk of the runner's default packages interfering with the script.

---
Supercedes https://github.com/arduino/actions/pull/85