### PR TITLE
Fix CI workflow for Python linting

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -32,19 +32,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.8.6'
+      - name: Run the set up script
+        id: setup
+        run: |
+          "${{ github.workspace }}/action-setup.sh"
 
       - name: Install flake8
         run: |
-          python -m pip install --upgrade pip
-          pip install --quiet flake8
-          pip install --quiet pep8-naming
+          source "${{ steps.setup.outputs.python-venv-activate-script-path }}"
+          "${{ steps.setup.outputs.python-command }}" \
+            -m \
+              pip install \
+                flake8 \
+                pep8-naming
 
       - name: Lint with flake8
         env:
           PYTHON_PROJECT_PATH: ${GITHUB_WORKSPACE}/compilesketches
         run: |
+          source "${{ steps.setup.outputs.python-venv-activate-script-path }}"
           flake8 --config "${{ env.PYTHON_PROJECT_PATH }}/.flake8" --show-source "${{ env.PYTHON_PROJECT_PATH }}"

--- a/compilesketches/.flake8
+++ b/compilesketches/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 doctests = True
+extend-exclude = .venv
 # W503 and W504 are mutually exclusive. PEP 8 recommends line break before.
 ignore = W503
 max-complexity = 10


### PR DESCRIPTION
The workflow was broken by the Python version it was using no longer being available from the `actions/setup-python
action`.

Rather than continuing in this fashion, it seems better to use the same setup script as is used by the action and unit
tests. This will ensure everything is done under the same environment.