### PR TITLE
Add Arduino CLI compile flags input

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/test-integration.yml'
-      - '.github/workflows/testdata'
+      - '.github/workflows/testdata/**'
       - 'action.yml'
       - 'action-setup.sh'
       - 'compilesketches/**'
@@ -12,7 +12,7 @@ on:
   push:
     paths:
       - '.github/workflows/test-integration.yml'
-      - '.github/workflows/testdata'
+      - '.github/workflows/testdata/**'
       - 'action.yml'
       - 'action-setup.sh'
       - 'compilesketches/**'
@@ -78,17 +78,26 @@ jobs:
         # Use action from local path
         uses: ./
         with:
-          cli-version: 0.13.0
+          cli-version: 0.15.1
           platforms: ${{ matrix.board.platforms }}
           fqbn: ${{ matrix.board.fqbn }}
           libraries: ${{ matrix.board.libraries }}
           sketch-paths: |
             - ${{ env.TESTDATA_SKETCHES_PATH }}/BareMinimum
             - ${{ env.TESTDATA_SKETCHES_PATH }}/ServoLibrary
+            - ${{ env.TESTDATA_SKETCHES_PATH }}/TestCompileFlags
+          cli-compile-flags: |
+            - --build-property
+            - compiler.cpp.extra_flags="-DSTRING_MACRO="hello world"" -DINT_MACRO=2 -DFLAG_MACRO
+            - --export-binaries
           enable-deltas-report: true
           enable-warnings-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
           verbose: true
+
+      - name: Verify --export-binaries flag was used by compilation command
+        run: |
+          [ -d ${{ env.TESTDATA_SKETCHES_PATH }}/BareMinimum/build ]
 
       - name: Set report artifact name
         id: report-artifact-name

--- a/.github/workflows/testdata/reports/all-inputs/arduino-avr-uno.json
+++ b/.github/workflows/testdata/reports/all-inputs/arduino-avr-uno.json
@@ -1,6 +1,6 @@
 {
-  "commit_hash": "d4343a2e7d8123726f2c53d2ac186df41b59e946",
-  "commit_url": "https://github.com/arduino/compile-sketches/commit/d4343a2e7d8123726f2c53d2ac186df41b59e946",
+  "commit_hash": "d2ed774ec1f37e6e497b6d629963cbc79632e9f9",
+  "commit_url": "https://github.com/arduino/compile-sketches/commit/d2ed774ec1f37e6e497b6d629963cbc79632e9f9",
   "boards": [
     {
       "board": "arduino:avr:uno",
@@ -97,6 +97,55 @@
             },
             "previous": {
               "absolute": 0
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": ".github/workflows/testdata/sketches/TestCompileFlags",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 32256,
+              "current": {
+                "absolute": 444,
+                "relative": 1.38
+              },
+              "previous": {
+                "absolute": 444,
+                "relative": 1.38
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 2048,
+              "current": {
+                "absolute": 9,
+                "relative": 0.44
+              },
+              "previous": {
+                "absolute": 9,
+                "relative": 0.44
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 1
+            },
+            "previous": {
+              "absolute": 1
             },
             "delta": {
               "absolute": 0

--- a/.github/workflows/testdata/reports/all-inputs/esp8266-esp8266-huzzah.json
+++ b/.github/workflows/testdata/reports/all-inputs/esp8266-esp8266-huzzah.json
@@ -1,6 +1,6 @@
 {
-  "commit_hash": "d4343a2e7d8123726f2c53d2ac186df41b59e946",
-  "commit_url": "https://github.com/arduino/compile-sketches/commit/d4343a2e7d8123726f2c53d2ac186df41b59e946",
+  "commit_hash": "d2ed774ec1f37e6e497b6d629963cbc79632e9f9",
+  "commit_url": "https://github.com/arduino/compile-sketches/commit/d2ed774ec1f37e6e497b6d629963cbc79632e9f9",
   "boards": [
     {
       "board": "esp8266:esp8266:huzzah",
@@ -97,6 +97,55 @@
             },
             "previous": {
               "absolute": 0
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": ".github/workflows/testdata/sketches/TestCompileFlags",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 1044464,
+              "current": {
+                "absolute": 256684,
+                "relative": 24.58
+              },
+              "previous": {
+                "absolute": 256684,
+                "relative": 24.58
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 81920,
+              "current": {
+                "absolute": 26776,
+                "relative": 32.69
+              },
+              "previous": {
+                "absolute": 26776,
+                "relative": 32.69
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 1
+            },
+            "previous": {
+              "absolute": 1
             },
             "delta": {
               "absolute": 0

--- a/.github/workflows/testdata/sketches/TestCompileFlags/TestCompileFlags.ino
+++ b/.github/workflows/testdata/sketches/TestCompileFlags/TestCompileFlags.ino
@@ -1,0 +1,12 @@
+#if INT_MACRO != 2
+#error
+#endif
+
+#ifndef FLAG_MACRO
+#error
+#endif
+
+void setup() {
+  char string[]=STRING_MACRO; // Will fail if the macro is not a string literal
+}
+void loop(){}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This action checks whether [Arduino](https://www.arduino.cc/) sketches compile a
       - [Repository](#repository-1)
       - [Archive download](#archive-download-1)
   - [`sketch-paths`](#sketch-paths)
+  - [`cli-compile-flags`](#cli-compile-flags)
   - [`verbose`](#verbose)
   - [`sketches-report-path`](#sketches-report-path)
   - [`github-token`](#github-token)
@@ -161,6 +162,12 @@ Keys:
 [YAML](https://en.wikipedia.org/wiki/YAML)-format list of paths containing sketches to compile. These paths will be searched recursively.
 
 **Default**: `"- examples"`
+
+### `cli-compile-flags`
+
+YAML-format list of flags to add to the Arduino CLI command used to compile the sketches. For the available flags, see [the Arduino CLI command reference](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_compile/#options).
+
+**Default**: `""`
 
 ### `verbose`
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'YAML-format list of paths containing sketches to compile.'
     default: '- examples'
     required: true
+  cli-compile-flags:
+    description: 'YAML-format list of flags to add to the Arduino CLI sketch compilation command.'
+    default: ''
+    required: false
   verbose:
     description: 'Set to true to show verbose output in the log'
     default: 'false'
@@ -62,6 +66,7 @@ runs:
         INPUT_LIBRARIES: ${{ inputs.libraries }}
         INPUT_PLATFORMS: ${{ inputs.platforms }}
         INPUT_SKETCH-PATHS: ${{ inputs.sketch-paths }}
+        INPUT_CLI-COMPILE-FLAGS: ${{ inputs.cli-compile-flags }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
         INPUT_GITHUB-TOKEN: ${{ inputs.github-token }}
         INPUT_ENABLE-DELTAS-REPORT: ${{ inputs.enable-deltas-report }}


### PR DESCRIPTION
This input allows the user to customize the sketch compilation process by defining arbitrary flags to be added to the
`arduino-cli compile` command.

In order to be as flexible as possible, the input uses a YAML list format:
```yaml
cli-compile-flags: |
  - --build-property
  - compiler.cpp.extra_flags="-DFOO="hello world"" -DPIN=2
  - --export-binaries
```

Closes https://github.com/arduino/compile-sketches/issues/16