### PR TITLE
Use major version refs in example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Set to `true` to cause the action to record the compiler warning count for each 
 ## Example usage
 
 ```yaml
-- uses: arduino/compile-sketches@main
+- uses: arduino/compile-sketches@v1
   with:
     fqbn: 'arduino:avr:uno'
     libraries: |


### PR DESCRIPTION
Previously, due to the lack of a release, the only option was to use the default branch name for the action ref. Using
release versions provides a more stable experience for the ordinary users of these actions and also eases ongoing
development work on the actions.

Use of the major version ref will cause the workflow to benefit from ongoing development to the action at each patch or
minor release up until such time as a new major release is made, at which time the user will be given the opportunity
to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release
before manually updating the major ref (e.g., `uses: arduino/compile-sketches@v2`).