### PR TITLE
Correctly detect and handle installation path collisions

### DIFF
--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -559,11 +559,14 @@ class CompileSketches:
 
         destination_path = destination_parent_path.joinpath(destination_name)
 
-        if destination_path.exists():
+        if destination_path.exists() or destination_path.is_symlink():
             if force:
-                # Clear existing folder
+                # Clear existing item
                 self.verbose_print("Overwriting installation at:", destination_path)
-                shutil.rmtree(path=destination_path)
+                if destination_path.is_symlink() or destination_path.is_file():
+                    destination_path.unlink()
+                else:
+                    shutil.rmtree(path=destination_path)
             else:
                 print("::error::Installation already exists:", destination_path)
                 sys.exit(1)


### PR DESCRIPTION
`compilesketches.CompileSketches.install_from_path()` has code for detecting a pree-xisting file/folder at the installation destination path and either removing it or else failing with a helpful error message depending on the setting of the `force` parameter.

The previous detection code did not work correctly in the event the pre-existing item was a broken symlink.

The previous removal code did not work correctly in the event the pre-existing item was a symlink or file.