### PR TITLE
Clean up dependencies installation symlinks on exit

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -114,6 +114,95 @@ jobs:
       report-artifact-name: ${{ steps.report-artifact-name.outputs.report-artifact-name }}
 
 
+  multiple-steps:
+    name: multiple-steps (${{ matrix.board.source-type }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - source-type: manager
+            fqbn: arduino:avr:uno
+            platforms: |
+              - name: arduino:avr
+                version: 1.8.3
+            libraries: |
+              - name: Servo
+                version: 1.1.7
+          - source-type: path
+            fqbn: arduino:avr:uno
+            platforms: |
+              - name: arduino:avr
+                version: 1.8.3
+              - source-path: extras/ArduinoCore-avr
+                name: arduino:avr
+            libraries: |
+              - source-path: ./
+                name: Servo
+          - source-type: repo
+            fqbn: arduino:avr:uno
+            platforms: |
+              - name: arduino:avr
+                version: 1.8.3
+              - source-url: https://github.com/arduino/ArduinoCore-avr.git
+                name: arduino:avr
+                version: 1.8.3
+            libraries: |
+              - source-url: https://github.com/arduino-libraries/Servo.git
+                name: Servo
+                version: 1.1.7
+          - source-type: archive
+            fqbn: arduino:avr:uno
+            platforms: |
+              - name: arduino:avr
+                version: 1.8.3
+              - source-url: https://github.com/arduino/ArduinoCore-avr/archive/refs/tags/1.8.3.zip
+                name: arduino:avr
+            libraries: |
+              - source-url: https://github.com/arduino-libraries/Servo/archive/refs/tags/1.1.7.zip
+                name: Servo
+
+    steps:
+      - name: Checkout library
+        uses: actions/checkout@v2
+        with:
+          repository: arduino-libraries/Servo
+          ref: 1.1.7
+
+      - name: Checkout platform
+        if: matrix.board.source-type == 'path'
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/ArduinoCore-avr
+          ref: 1.8.3
+          path: extras/ArduinoCore-avr
+
+      - name: Checkout local repo
+        uses: actions/checkout@v2
+        with:
+          path: extras/compile-sketches
+
+      - name: Run action
+        # Use action from local path
+        uses: ./extras/compile-sketches
+        with:
+          platforms: ${{ matrix.board.platforms }}
+          fqbn: ${{ matrix.board.fqbn }}
+          libraries: ${{ matrix.board.libraries }}
+          sketch-paths: |
+            - examples/Sweep
+
+      - name: Run action again
+        uses: ./extras/compile-sketches
+        with:
+          platforms: ${{ matrix.board.platforms }}
+          fqbn: ${{ matrix.board.fqbn }}
+          libraries: ${{ matrix.board.libraries }}
+          sketch-paths: |
+            - examples/Sweep
+
   check-sketches-reports:
     needs: all-inputs
     runs-on: ubuntu-latest

--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -1,3 +1,4 @@
+import atexit
 import contextlib
 import enum
 import json
@@ -575,6 +576,10 @@ class CompileSketches:
         destination_parent_path.mkdir(parents=True, exist_ok=True)
 
         destination_path.symlink_to(target=source_path, target_is_directory=source_path.is_dir())
+
+        # Remove the symlink on script exit. The source path files added by the script are stored in a temporary folder
+        # which is deleted on exit, so the symlink will serve no purpose.
+        atexit.register(destination_path.unlink)
 
     def install_platforms_from_repository(self, platform_list):
         """Install libraries by cloning Git repositories


### PR DESCRIPTION
The code used to install Arduino CLI, platform, and library dependencies does so by creating symlinks in the appropriate locations on the runner. The files the script gathers via clone or download, are stored in a temporary folder that is deleted when the script exits. This means the installation symlink for those files has no possible use after the script finishes.

This particular pollution of the runner's environment is resolved by also registering a call to delete on exit as each symlink is created.