### PR TITLE
Bump codecov/codecov-action to v2

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -78,7 +78,7 @@ jobs:
               coverage report
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: ${{ env.COVERAGE_DATA_FILENAME }}
           fail_ci_if_error: true


### PR DESCRIPTION
[The `codecov/codecov-action` GitHub Actions action](https://github.com/codecov/codecov-action) is used in the "Test Python code" workflow to upload code coverage data to Codecov.

The previously used `codecov/codecov-action@v1` version is deprecated and will cease working in less than a month:
https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1

The use of the `v2` major version ref will cause the workflow to use a stable version of the action, while also benefiting from ongoing development to the action up until such time as a new major release of an action is made. At that time we would need to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref (e.g., uses: `codecov/codecov-action@v3`).

---
Supersedes https://github.com/arduino/compile-sketches/pull/35