### PR TITLE
Declare and assign variable separately in setup script

### DIFF
--- a/action-setup.sh
+++ b/action-setup.sh
@@ -5,7 +5,7 @@
 readonly PYTHON_PACKAGE_VERSION='3.8'
 
 # https://stackoverflow.com/a/29835459
-readonly SCRIPT_PATH="$(
+SCRIPT_PATH="$(
   CDPATH='' \
   cd -- "$(
     dirname -- "$0"
@@ -13,6 +13,7 @@ readonly SCRIPT_PATH="$(
     pwd -P
   )
 )"
+readonly SCRIPT_PATH
 
 readonly PYTHON_COMMAND="python${PYTHON_PACKAGE_VERSION}"
 readonly PYTHON_VENV_PATH="${SCRIPT_PATH}/compilesketches/.venv"


### PR DESCRIPTION
Coverage of `readonly` was added (`koalaman/shellcheck#2077`) to ShellCheck rule SC2155:

https://github.com/koalaman/shellcheck/wiki/SC2155#problematic-code-in-the-case-of-readonly

> ### Problematic code in the case of `readonly`:
>
> ```sh
> readonly foo="$(mycmd)"
> ```
>
> #### Correct code:
>
> ```sh
> foo="$(mycmd)"
> readonly foo
> ```

There is this sort of "problematic code" in the action setup script, which caused the "Lint shell scripts" CI workflow to start
failing after the 0.7.2 release of ShellCheck:

https://github.com/arduino/compile-sketches/actions/workflows/lint-shell.yml

The script's usage of `readonly` is now adjusted according to [ShellCheck](https://github.com/koalaman/shellcheck)'s recommendation.