### PR TITLE
output compilation time for each sketch

### DIFF
--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -1,4 +1,5 @@
 import atexit
+import time
 import contextlib
 import enum
 import json
@@ -893,13 +894,22 @@ class CompileSketches:
         if clean_build_cache:
             for cache_path in pathlib.Path("/tmp").glob(pattern="arduino*"):
                 shutil.rmtree(path=cache_path)
-
+        start_time = time.monotonic()
         compilation_data = self.run_arduino_cli_command(
             command=compilation_command, enable_output=self.RunCommandOutput.NONE, exit_on_failure=False)
+        diff_time = time.monotonic() - start_time
+        time_summary = ""
+        if diff_time > 60:
+            if diff_time > 360:
+                time_summary += f"{int(diff_time / 360)} hours "
+            time_summary += f"{int(diff_time / 60) % 60} minutes "
+        time_summary += f"{int(diff_time) % 60} seconds."
+
         # Group compilation output to make the log easy to read
         # https://github.com/actions/toolkit/blob/master/docs/commands.md#group-and-ungroup-log-lines
         print("::group::Compiling sketch:", path_relative_to_workspace(path=sketch_path))
         print(compilation_data.stdout)
+        print("Compilation time elapsed", time_summary)
         print("::endgroup::")
 
         class CompilationResult:

--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -919,7 +919,7 @@ class CompileSketches:
                     time_summary += f"{int(diff_time / 360)}h "
                 time_summary += f"{int(diff_time / 60) % 60}m "
             time_summary += f"{int(diff_time) % 60}s"
-            print("Compilation time elapsed", time_summary)
+            print("Compilation time elapsed:", time_summary)
 
         return CompilationResult()
 

--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -916,9 +916,9 @@ class CompileSketches:
             time_summary = ""
             if diff_time > 60:
                 if diff_time > 360:
-                    time_summary += f"{int(diff_time / 360)} h "
-                time_summary += f"{int(diff_time / 60) % 60} m "
-            time_summary += f"{int(diff_time) % 60} s"
+                    time_summary += f"{int(diff_time / 360)}h "
+                time_summary += f"{int(diff_time / 60) % 60}m "
+            time_summary += f"{int(diff_time) % 60}s"
             print("Compilation time elapsed", time_summary)
 
         return CompilationResult()

--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -898,18 +898,11 @@ class CompileSketches:
         compilation_data = self.run_arduino_cli_command(
             command=compilation_command, enable_output=self.RunCommandOutput.NONE, exit_on_failure=False)
         diff_time = time.monotonic() - start_time
-        time_summary = ""
-        if diff_time > 60:
-            if diff_time > 360:
-                time_summary += f"{int(diff_time / 360)} hours "
-            time_summary += f"{int(diff_time / 60) % 60} minutes "
-        time_summary += f"{int(diff_time) % 60} seconds."
 
         # Group compilation output to make the log easy to read
         # https://github.com/actions/toolkit/blob/master/docs/commands.md#group-and-ungroup-log-lines
         print("::group::Compiling sketch:", path_relative_to_workspace(path=sketch_path))
         print(compilation_data.stdout)
-        print("Compilation time elapsed", time_summary)
         print("::endgroup::")
 
         class CompilationResult:
@@ -919,6 +912,14 @@ class CompileSketches:
 
         if not CompilationResult.success:
             print("::error::Compilation failed")
+        else:
+            time_summary = ""
+            if diff_time > 60:
+                if diff_time > 360:
+                    time_summary += f"{int(diff_time / 360)} h "
+                time_summary += f"{int(diff_time / 60) % 60} m "
+            time_summary += f"{int(diff_time) % 60} s"
+            print("Compilation time elapsed", time_summary)
 
         return CompilationResult()
 

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -1435,11 +1435,12 @@ def test_compile_sketch(capsys, mocker, clean_build_cache, returncode, expected_
     expected_stdout = (
         "::group::Compiling sketch: " + str(compilesketches.path_relative_to_workspace(path=sketch_path)) + "\n"
         + str(stdout) + "\n"
-        + "Compilation time elapsed 0 seconds.\n"
         + "::endgroup::"
     )
     if not expected_success:
         expected_stdout += "\n::error::Compilation failed"
+    else:
+        expected_stdout += "\nCompilation time elapsed 0s"
     assert capsys.readouterr().out.strip() == expected_stdout
 
     assert compilation_result.sketch == sketch_path

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -1435,6 +1435,7 @@ def test_compile_sketch(capsys, mocker, clean_build_cache, returncode, expected_
     expected_stdout = (
         "::group::Compiling sketch: " + str(compilesketches.path_relative_to_workspace(path=sketch_path)) + "\n"
         + str(stdout) + "\n"
+        + "Compilation time elapsed 0 seconds.\n"
         + "::endgroup::"
     )
     if not expected_success:

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -1440,7 +1440,7 @@ def test_compile_sketch(capsys, mocker, clean_build_cache, returncode, expected_
     if not expected_success:
         expected_stdout += "\n::error::Compilation failed"
     else:
-        expected_stdout += "\nCompilation time elapsed 0s"
+        expected_stdout += "\nCompilation time elapsed: 0s"
     assert capsys.readouterr().out.strip() == expected_stdout
 
     assert compilation_result.sketch == sketch_path


### PR DESCRIPTION
resolves #59 

This is a very simple approach. If I knew the code-base better, then I'd decorate a function (like `run_command()`), but the basic aim for #59 is only meant for timing compilation of sketches instead of other action operations.