### PR TITLE
update set-output cmds

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           # Use of this flag in the github-label-sync command will cause it to only check the validity of the
           # configuration.
-          echo "::set-output name=flag::--dry-run"
+          echo "flag=--dry-run" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Set report artifact name
         id: report-artifact-name
         run: |
-          echo "::set-output name=report-artifact-name::${{ github.job }}"
+          echo "report-artifact-name=${{ github.job }}" >> "$GITHUB_OUTPUT"
 
       - name: Save sketches report as workflow artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
resolves #86 

I use this action in a number of large matrix jobs, so I get _a lot_ of repeated warnings.