### PR TITLE
Add infrastructure for checking project filesystem

### DIFF
--- a/.github/workflows/check-files-task.yml
+++ b/.github/workflows/check-files-task.yml
@@ -1,0 +1,73 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-files-task.md
+name: Check Files
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  create:
+  push:
+  pull_request:
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * THU"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+  check-filenames:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check filenames
+        run: task --silent general:check-filenames
+
+  check-symlinks:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check symlinks
+        run: task --silent general:check-symlinks

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `arduino/compile-sketches` action
 
 [![Check Action Metadata status](https://github.com/arduino/compile-sketches/actions/workflows/check-action-metadata-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-action-metadata-task.yml)
+[![Check Files status](https://github.com/arduino/compile-sketches/actions/workflows/check-files-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-files-task.yml)
 [![Check Python status](https://github.com/arduino/compile-sketches/actions/workflows/check-python-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-python-task.yml)
 [![Spell Check status](https://github.com/arduino/compile-sketches/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/spell-check-task.yml)
 [![Sync Labels status](https://github.com/arduino/compile-sketches/actions/workflows/sync-labels-npm.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/sync-labels-npm.yml)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,6 +41,76 @@ tasks:
             -s "{{.ACTION_METADATA_SCHEMA_PATH}}" \
             -d "action.yml"
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-files-task/Taskfile.yml
+  general:check-filenames:
+    desc: Check for non-portable filenames
+    cmds:
+      - |
+        find . \
+          -type d -name '.git' -prune -o \
+          -type d -name '.licenses' -prune -o \
+          -type d -name '__pycache__' -prune -o \
+          -type d -name 'node_modules' -prune -o \
+          -exec \
+            sh \
+              -c \
+                ' \
+                  basename "$0" | \
+                    grep \
+                      --perl-regexp \
+                      --regexp='"'"'([<>:"/\\|?*\x{0000}-\x{001F}])|(.+\.$)'"'"' \
+                      --silent \
+                  && \
+                  echo "$0"
+                ' \
+              '{}' \
+            \; \
+          -execdir \
+            false \
+            '{}' \
+            + \
+        || \
+        {
+          echo
+          echo "Prohibited characters found in filenames"
+          echo "See:"
+          echo "https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions:~:text=except%20for%20the%20following"
+          false
+        }
+      - |
+        find . \
+          -type d -name '.git' -prune -o \
+          -type d -name '.licenses' -prune -o \
+          -type d -name '__pycache__' -prune -o \
+          -type d -name 'node_modules' -prune -o \
+          -exec \
+            sh \
+              -c \
+                ' \
+                  basename "$0" | \
+                    grep \
+                      --ignore-case \
+                      --extended-regexp \
+                      --regexp='"'"'^(con|prn|aux|nul|com[0-9]+|lpt[0-9]+)$'"'"' \
+                      --silent \
+                  && \
+                  echo "$0"
+                ' \
+              '{}' \
+            \; \
+          -execdir \
+            false \
+            '{}' \
+            + \
+        || \
+        {
+          echo
+          echo "Reserved filenames found"
+          echo "See:"
+          echo "https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions:~:text=use%20the%20following-,reserved%20names,-for%20the%20name"
+          false
+        }
+
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
   general:check-spelling:
     desc: Check for commonly misspelled words
@@ -50,6 +120,33 @@ tasks:
           POETRY_GROUPS: dev
     cmds:
       - poetry run codespell
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-files-task/Taskfile.yml
+  general:check-symlinks:
+    desc: Check for bad symlinks
+    cmds:
+      - |
+        find . \
+          -type d -name '.git' -prune -o \
+          -type d -name '.licenses' -prune -o \
+          -type d -name '__pycache__' -prune -o \
+          -type d -name 'node_modules' -prune -o \
+          -type l \
+          -execdir \
+            test ! -e '{}' \
+            \; \
+          -exec \
+            echo '{}' \
+            \; \
+          -execdir \
+            false \
+            '{}' \
+            + \
+        || \
+        {
+          echo 'Broken or circular symlink found'
+          false
+        }
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
   general:correct-spelling:


### PR DESCRIPTION
There are differences in the filename restrictions between operating systems. The use of filenames that are not valid on one operating system in the project will cause problems for contributors or users (e.g., not possible to check out the repository).

Tasks are added to check for non-portable filenames:

- Presence of characters prohibited by an operating system in filenames
- Use of filenames reserved by an operating system

Tasks are also added to check for problems with symbolic links ("symlinks") contained in the project:

- Broken symlinks
- Circular symlinks

A GitHub Actions workflow is included to run the tasks on any change to the project files in order to avoid the introduction of problems with the project filesystem, and periodically in order to catch breakage caused by external changes.