### PR TITLE
Add infrastructure to check for problems with npm configuration files

### DIFF
--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -1,0 +1,103 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-npm-task.md
+name: Check npm
+
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 16.x
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - ".github/workflows/check-npm-task.ya?ml"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-npm-task.ya?ml"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+  validate:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate package.json
+        run: task --silent npm:validate
+
+  check-sync:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Install npm dependencies
+        run: task npm:install-deps
+
+      - name: Check package-lock.json
+        run: git diff --color --exit-code package-lock.json

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Check General Formatting status](https://github.com/arduino/compile-sketches/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-general-formatting-task.yml)
 [![Check License status](https://github.com/arduino/compile-sketches/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-license.ym
 [![Check Markdown status](https://github.com/arduino/compile-sketches/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-markdown-task.yml)
+[![Check npm status](https://github.com/arduino/compile-sketches/actions/workflows/check-npm-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-npm-task.yml)
 [![Check Python status](https://github.com/arduino/compile-sketches/actions/workflows/check-python-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-python-task.yml)
 [![Spell Check status](https://github.com/arduino/compile-sketches/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/spell-check-task.yml)
 [![Sync Labels status](https://github.com/arduino/compile-sketches/actions/workflows/sync-labels-npm.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/sync-labels-npm.yml)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,8 @@ version: "3"
 
 vars:
   PYTHON_PROJECT_PATH: compilesketches
+  # Last version of ajv-cli with support for the JSON schema "Draft 4" specification
+  SCHEMA_DRAFT_4_AJV_CLI_VERSION: 3.3.0
 
 tasks:
   check:
@@ -260,6 +262,70 @@ tasks:
     run: once
     cmds:
       - npm install
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-npm-task/Taskfile.yml
+  npm:validate:
+    desc: Validate npm configuration files against their JSON schema
+    vars:
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json
+      SCHEMA_URL: https://json.schemastore.org/package.json
+      SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="package-json-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/ava.json
+      AVA_SCHEMA_URL: https://json.schemastore.org/ava.json
+      AVA_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="ava-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/eslintrc.json
+      ESLINTRC_SCHEMA_URL: https://json.schemastore.org/eslintrc.json
+      ESLINTRC_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="eslintrc-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/jscpd.json
+      JSCPD_SCHEMA_URL: https://json.schemastore.org/jscpd.json
+      JSCPD_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="jscpd-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/npm-badges.json
+      NPM_BADGES_SCHEMA_URL: https://json.schemastore.org/npm-badges.json
+      NPM_BADGES_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="npm-badges-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/prettierrc.json
+      PRETTIERRC_SCHEMA_URL: https://json.schemastore.org/prettierrc.json
+      PRETTIERRC_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="prettierrc-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/semantic-release.json
+      SEMANTIC_RELEASE_SCHEMA_URL: https://json.schemastore.org/semantic-release.json
+      SEMANTIC_RELEASE_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="semantic-release-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/stylelintrc.json
+      STYLELINTRC_SCHEMA_URL: https://json.schemastore.org/stylelintrc.json
+      STYLELINTRC_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
+      INSTANCE_PATH: "**/package.json"
+      PROJECT_FOLDER:
+        sh: pwd
+      WORKING_FOLDER:
+        sh: task utility:mktemp-folder TEMPLATE="dependabot-validate-XXXXXXXXXX"
+    cmds:
+      - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
+      - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.ESLINTRC_SCHEMA_PATH}}" {{.ESLINTRC_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.JSCPD_SCHEMA_PATH}}" {{.JSCPD_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.NPM_BADGES_SCHEMA_PATH}}" {{.NPM_BADGES_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.PRETTIERRC_SCHEMA_PATH}}" {{.PRETTIERRC_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
+      - |
+        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
+        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
+          --all-errors \
+          -s "{{.SCHEMA_PATH}}" \
+          -r "{{.AVA_SCHEMA_PATH}}" \
+          -r "{{.ESLINTRC_SCHEMA_PATH}}" \
+          -r "{{.JSCPD_SCHEMA_PATH}}" \
+          -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
+          -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
+          -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
+          -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
+          -d "{{.PROJECT_FOLDER}}/{{.INSTANCE_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:


### PR DESCRIPTION
A [task](https://taskfile.dev/) and GitHub Actions workflow are provided here for checking the project's **npm** package manager configuration.

On every push and pull request that affects relevant files, and periodically:

- Validate [`package.json`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json) against [its JSON schema](https://json.schemastore.org/package.json).
- Check for forgotten [`package-lock.json`](https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json) syncs.