### PR TITLE
Use correct syntax for empty YAML sequence

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -72,7 +72,7 @@ jobs:
             libraries: |
               # The official Servo library is not compatible with ESP8266, but that platform has a bundled Servo lib
               # so there are no library dependencies
-              -
+              []
 
     steps:
       - name: Checkout
@@ -348,7 +348,7 @@ jobs:
           fqbn: arduino:avr:uno
           github-token: ${{ secrets.GITHUB_TOKEN }}
           libraries: |
-            -
+            []
           sketch-paths: |
             - ${{ env.TESTDATA_SKETCHES_PATH }}/Error
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Check Action Metadata status](https://github.com/arduino/compile-sketches/actions/workflows/check-action-metadata-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-action-metadata-task.yml)
 [![Check Files status](https://github.com/arduino/compile-sketches/actions/workflows/check-files-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-files-task.yml)
 [![Check General Formatting status](https://github.com/arduino/compile-sketches/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-general-formatting-task.yml)
-[![Check License status](https://github.com/arduino/compile-sketches/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-license.ym
+[![Check License status](https://github.com/arduino/compile-sketches/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-license.yml)
 [![Check Markdown status](https://github.com/arduino/compile-sketches/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-markdown-task.yml)
 [![Check npm status](https://github.com/arduino/compile-sketches/actions/workflows/check-npm-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-npm-task.yml)
 [![Check Prettier Formatting status](https://github.com/arduino/compile-sketches/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/compile-sketches/actions/workflows/check-prettier-formatting-task.yml)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Keys:
 [YAML](https://en.wikipedia.org/wiki/YAML)-format list of library dependencies to install.
 
 **Default**: `"- source-path: ./"`
-This causes the repository to be installed as a library. If there are no library dependencies and you want to override the default, set the `libraries` input to an empty list (`- libraries: '-'`).
+This causes the repository to be installed as a library. If there are no library dependencies and you want to override the default, set the `libraries` input to an empty list (`- libraries: '[]'`).
 
 Libraries are installed under the Arduino user folder at `~/Arduino/libraries`.
 

--- a/action.yml
+++ b/action.yml
@@ -1,48 +1,64 @@
 name: "Compile Arduino Sketches"
-description: "Checks whether Arduino sketches will compile and produces a report of data from the compilations"
+description: >-
+  Checks whether Arduino sketches will compile and produces a report of data from the compilations
 inputs:
   cli-version:
-    description: "Version of Arduino CLI to use when building"
+    description: >-
+      Version of Arduino CLI to use when building
     default: "latest"
     required: true
   fqbn:
-    description: "Full qualified board name, with Boards Manager URL if needed"
+    description: >-
+      Full qualified board name, with Boards Manager URL if needed
     default: "arduino:avr:uno"
     required: true
   libraries:
-    description: "YAML-format list of library dependencies to install"
+    description: >-
+      YAML-format list of library dependencies to install
     default: "- source-path: ./"
     required: true
   platforms:
-    description: "YAML-format list of platform dependencies to install"
+    description: >-
+      YAML-format list of platform dependencies to install
     default: ""
     required: true
   sketch-paths:
-    description: "YAML-format list of paths containing sketches to compile."
+    description: >-
+      YAML-format list of paths containing sketches to compile.
     default: "- examples"
     required: true
   cli-compile-flags:
-    description: "YAML-format list of flags to add to the Arduino CLI sketch compilation command."
+    description: >-
+      YAML-format list of flags to add to the Arduino CLI sketch compilation command.
     default: ""
     required: false
   verbose:
-    description: "Set to true to show verbose output in the log"
+    description: >-
+      Set to true to show verbose output in the log
     default: "false"
     required: true
   sketches-report-path:
-    description: "Path in which to save a JSON formatted file containing data from the sketch compilations"
+    description: >-
+      Path in which to save a JSON formatted file containing data from the sketch compilations
     default: "sketches-reports"
     required: true
   github-token:
-    description: "GitHub access token used to get information from the GitHub API. Only needed if you are using the deltas report feature in a private repository."
+    description: >-
+      GitHub access token used to get information from the GitHub API.
+
+      Only needed if you are using the deltas report feature in a private repository.
     default: ""
     required: true
   enable-deltas-report:
-    description: "Set to true to cause the action to determine the change in memory usage and compiler warnings of the compiled sketches between the head and base refs of a PR and the immediate parent commit of a push"
+    description: >-
+      Set to true to cause the action to determine the change in memory usage and compiler warnings of the compiled
+      sketches between the head and base refs of a PR and the immediate parent commit of a push
     default: "false"
     required: true
   enable-warnings-report:
-    description: "Set to true to cause the action to record the compiler warning count for each sketch compilation in the sketches report"
+    description: >-
+      Set to true to cause the action to record the compiler warning count for each sketch compilation in the sketches
+      report
     default: "false"
     required: true
 

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -1070,6 +1070,7 @@ def test_install_platforms_from_download(mocker):
             [],
         ),
         ("-", [], [], [], []),
+        ("[]", [], [], [], []),
         (
             "- " + compilesketches.CompileSketches.dependency_name_key + ": foo",
             [{compilesketches.CompileSketches.dependency_name_key: "foo"}],


### PR DESCRIPTION
Unlike the other [inputs](https://github.com/arduino/compile-sketches#inputs) ([`platforms`](https://github.com/arduino/compile-sketches#platforms), [`sketch-paths`](https://github.com/arduino/compile-sketches#sketch-paths)) that use a "[sequence](https://yaml.org/spec/1.2.2/#sequence)" (AKA array, list) type YAML document, because a sketch may have no library dependencies it is valid and common to pass an empty sequence via the [`libraries` input](https://github.com/arduino/compile-sketches/tree/c9dd641988f42b2148a46f7ec93c8ffa59ecda1d#libraries).

Due to the need to maintain backwards compatibility with the original short-sighted design of the action API, which didn't consider the action being used with any project type other than libraries, it is necessary for the user to do this in their workflow rather than simply [omitting the `libraries` input](https://github.com/arduino/compile-sketches/tree/c9dd641988f42b2148a46f7ec93c8ffa59ecda1d#libraries:~:text=dependencies%20to%20install.-,Default,-%3A%20%22%2D%20source%2Dpath).

Previously the documentation and tests used `"-"` for this purpose. That is supported, but is not an empty sequence, but rather a sequence consisting of a single null element. The only way to specify an empty sequence in YAML is `[]`.