### PR TITLE
Always add size summary report to sketches report

### DIFF
--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -1300,55 +1300,52 @@ class CompileSketches:
         sizes_summary_report = []
         for sketch_report in sketch_report_list:
             for size_report in sketch_report[self.ReportKeys.sizes]:
-                if self.ReportKeys.delta in size_report:
-                    # Determine the sizes_summary_report index for this memory type
-                    size_summary_report_index_list = [
-                        index
-                        for index, size_summary in enumerate(sizes_summary_report)
-                        if size_summary.get(self.ReportKeys.name) == size_report[self.ReportKeys.name]
+                # Determine the sizes_summary_report index for this memory type
+                size_summary_report_index_list = [
+                    index
+                    for index, size_summary in enumerate(sizes_summary_report)
+                    if size_summary.get(self.ReportKeys.name) == size_report[self.ReportKeys.name]
+                ]
+                if not size_summary_report_index_list:
+                    # There is no existing entry in the summary list for this memory type, so create one
+                    sizes_summary_report.append({self.ReportKeys.name: size_report[self.ReportKeys.name]})
+                    size_summary_report_index = len(sizes_summary_report) - 1
+                else:
+                    size_summary_report_index = size_summary_report_index_list[0]
+
+                if (
+                    self.ReportKeys.maximum not in sizes_summary_report[size_summary_report_index]
+                    or sizes_summary_report[size_summary_report_index][self.ReportKeys.maximum]
+                    == self.not_applicable_indicator
+                ):
+                    sizes_summary_report[size_summary_report_index][self.ReportKeys.maximum] = size_report[
+                        self.ReportKeys.maximum
                     ]
-                    if not size_summary_report_index_list:
-                        # There is no existing entry in the summary list for this memory type, so create one
-                        sizes_summary_report.append(
-                            {
-                                self.ReportKeys.name: size_report[self.ReportKeys.name],
-                                self.ReportKeys.maximum: size_report[self.ReportKeys.maximum],
-                                self.ReportKeys.delta: {
-                                    self.ReportKeys.absolute: {
-                                        self.ReportKeys.minimum: size_report[self.ReportKeys.delta][
-                                            self.ReportKeys.absolute
-                                        ],
-                                        self.ReportKeys.maximum: size_report[self.ReportKeys.delta][
-                                            self.ReportKeys.absolute
-                                        ],
-                                    },
-                                    self.ReportKeys.relative: {
-                                        self.ReportKeys.minimum: size_report[self.ReportKeys.delta][
-                                            self.ReportKeys.relative
-                                        ],
-                                        self.ReportKeys.maximum: size_report[self.ReportKeys.delta][
-                                            self.ReportKeys.relative
-                                        ],
-                                    },
-                                },
-                            }
-                        )
-                    else:
-                        size_summary_report_index = size_summary_report_index_list[0]
 
+                if self.ReportKeys.delta in size_report:
+                    if (
+                        self.ReportKeys.delta not in sizes_summary_report[size_summary_report_index]
+                        or sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
+                            self.ReportKeys.absolute
+                        ][self.ReportKeys.minimum]
+                        == self.not_applicable_indicator
+                    ):
+                        sizes_summary_report[size_summary_report_index][self.ReportKeys.delta] = {
+                            self.ReportKeys.absolute: {
+                                self.ReportKeys.minimum: size_report[self.ReportKeys.delta][self.ReportKeys.absolute],
+                                self.ReportKeys.maximum: size_report[self.ReportKeys.delta][self.ReportKeys.absolute],
+                            },
+                            self.ReportKeys.relative: {
+                                self.ReportKeys.minimum: size_report[self.ReportKeys.delta][self.ReportKeys.relative],
+                                self.ReportKeys.maximum: size_report[self.ReportKeys.delta][self.ReportKeys.relative],
+                            },
+                        }
+                    elif size_report[self.ReportKeys.delta][self.ReportKeys.absolute] != self.not_applicable_indicator:
                         if (
-                            sizes_summary_report[size_summary_report_index][self.ReportKeys.maximum]
-                            == self.not_applicable_indicator
-                        ):
-                            sizes_summary_report[size_summary_report_index][self.ReportKeys.maximum] = size_report[
-                                self.ReportKeys.maximum
-                            ]
-
-                        if (
-                            sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
+                            size_report[self.ReportKeys.delta][self.ReportKeys.absolute]
+                            < sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
                                 self.ReportKeys.absolute
                             ][self.ReportKeys.minimum]
-                            == self.not_applicable_indicator
                         ):
                             sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
                                 self.ReportKeys.absolute
@@ -1358,6 +1355,12 @@ class CompileSketches:
                                 self.ReportKeys.relative
                             ][self.ReportKeys.minimum] = size_report[self.ReportKeys.delta][self.ReportKeys.relative]
 
+                        if (
+                            size_report[self.ReportKeys.delta][self.ReportKeys.absolute]
+                            > sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
+                                self.ReportKeys.absolute
+                            ][self.ReportKeys.maximum]
+                        ):
                             sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
                                 self.ReportKeys.absolute
                             ][self.ReportKeys.maximum] = size_report[self.ReportKeys.delta][self.ReportKeys.absolute]
@@ -1365,45 +1368,6 @@ class CompileSketches:
                             sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
                                 self.ReportKeys.relative
                             ][self.ReportKeys.maximum] = size_report[self.ReportKeys.delta][self.ReportKeys.relative]
-
-                        elif size_report[self.ReportKeys.delta][self.ReportKeys.absolute] != (
-                            self.not_applicable_indicator
-                        ):
-                            if (
-                                size_report[self.ReportKeys.delta][self.ReportKeys.absolute]
-                                < sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
-                                    self.ReportKeys.absolute
-                                ][self.ReportKeys.minimum]
-                            ):
-                                sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
-                                    self.ReportKeys.absolute
-                                ][self.ReportKeys.minimum] = size_report[self.ReportKeys.delta][
-                                    self.ReportKeys.absolute
-                                ]
-
-                                sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
-                                    self.ReportKeys.relative
-                                ][self.ReportKeys.minimum] = size_report[self.ReportKeys.delta][
-                                    self.ReportKeys.relative
-                                ]
-
-                            if (
-                                size_report[self.ReportKeys.delta][self.ReportKeys.absolute]
-                                > sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
-                                    self.ReportKeys.absolute
-                                ][self.ReportKeys.maximum]
-                            ):
-                                sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
-                                    self.ReportKeys.absolute
-                                ][self.ReportKeys.maximum] = size_report[self.ReportKeys.delta][
-                                    self.ReportKeys.absolute
-                                ]
-
-                                sizes_summary_report[size_summary_report_index][self.ReportKeys.delta][
-                                    self.ReportKeys.relative
-                                ][self.ReportKeys.maximum] = size_report[self.ReportKeys.delta][
-                                    self.ReportKeys.relative
-                                ]
 
         return sizes_summary_report
 

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -2621,7 +2621,7 @@ def test_get_sizes_summary_report():
                 },
                 {
                     compilesketches.CompileSketches.ReportKeys.name: "Bar memory type",
-                    compilesketches.CompileSketches.ReportKeys.maximum: 111,
+                    compilesketches.CompileSketches.ReportKeys.maximum: 222,
                     compilesketches.CompileSketches.ReportKeys.current: {
                         compilesketches.CompileSketches.ReportKeys.absolute: 33,
                         compilesketches.CompileSketches.ReportKeys.relative: 3.342,

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -1803,6 +1803,28 @@ def test_get_sketch_report(mocker, enable_warnings_report, do_deltas_report):
             "                                       ^~~~~\n"
             "Sketch uses {flash} bytes (4%) of program storage space. Maximum is {maximum_flash} bytes.\n",
             12636,
+            25272,
+            50.0,
+            get_compilesketches_object().not_applicable_indicator,
+            get_compilesketches_object().not_applicable_indicator,
+            get_compilesketches_object().not_applicable_indicator,
+        ),
+        (
+            True,
+            "/home/per/Arduino/libraries/Servo/src/samd/Servo.cpp: In function 'void _initISR(Tc*, uint8_t, uint32_t, IRQn_Ty"
+            "pe, uint8_t, uint8_t)':\n"
+            "/home/per/Arduino/libraries/Servo/src/samd/Servo.cpp:120:56: warning: unused parameter 'id' [-Wunused-parameter]"
+            "\n"
+            " static void _initISR(Tc *tc, uint8_t channel, uint32_t id, IRQn_Type irqn, uint8_t gcmForTimer, uint8_t intEnab"
+            " leBit)\n"
+            "                                                        ^~\n"
+            "/home/per/Arduino/libraries/Servo/src/samd/Servo.cpp: In function 'void finISR(timer16_Sequence_t)':\n"
+            "/home/per/Arduino/libraries/Servo/src/samd/Servo.cpp:174:39: warning: unused parameter 'timer' [-Wunused-paramet"
+            "er]\n"
+            " static void finISR(timer16_Sequence_t timer)\n"
+            "                                       ^~~~~\n"
+            "Sketch uses {flash} bytes (4%) of program storage space.\n",
+            12636,
             get_compilesketches_object().not_applicable_indicator,
             get_compilesketches_object().not_applicable_indicator,
             get_compilesketches_object().not_applicable_indicator,

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -2631,7 +2631,16 @@ def test_get_sizes_summary_report():
         },
     ]
 
-    expected_sizes_summary_report = []
+    expected_sizes_summary_report = [
+        {
+            compilesketches.CompileSketches.ReportKeys.name: "Foo memory type",
+            compilesketches.CompileSketches.ReportKeys.maximum: 111,
+        },
+        {
+            compilesketches.CompileSketches.ReportKeys.name: "Bar memory type",
+            compilesketches.CompileSketches.ReportKeys.maximum: 222,
+        },
+    ]
 
     assert compile_sketches.get_sizes_summary_report(sketch_report_list=sketch_report_list) == (
         expected_sizes_summary_report


### PR DESCRIPTION
In addition to per-sketch, per-board memory usage data, the sketches report contains a per-board summary of the results from all the compilations for that board.

Previously, when deltas data was not available, this summary section was arbitrarily omitted entirely from the sketches report. However, there is still board-universal information even without deltas:

- Memory types
- Maximums for each memory type

It is useful to have that information available on a per-board level so a summary report should always be added to the sketches report.
