### PR TITLE
[AE-170][AE-158] Make `example usage` self contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,31 +23,33 @@ This action checks whether [Arduino](https://www.arduino.cc/) sketches compile a
 
 <!-- toc -->
 
-- [Inputs](#inputs)
-  - [`cli-version`](#cli-version)
-  - [`fqbn`](#fqbn)
-  - [`platforms`](#platforms)
-    - [Supported platform sources:](#supported-platform-sources)
-      - [Boards Manager](#boards-manager)
-      - [Local path](#local-path)
-      - [Repository](#repository)
-      - [Archive download](#archive-download)
-  - [`libraries`](#libraries)
-    - [Supported library sources:](#supported-library-sources)
-      - [Library Manager](#library-manager)
-      - [Local path](#local-path-1)
-      - [Repository](#repository-1)
-      - [Archive download](#archive-download-1)
-  - [`sketch-paths`](#sketch-paths)
-  - [`cli-compile-flags`](#cli-compile-flags)
-  - [`verbose`](#verbose)
-  - [`sketches-report-path`](#sketches-report-path)
-  - [`github-token`](#github-token)
-  - [`enable-deltas-report`](#enable-deltas-report)
-    - [How it works](#how-it-works)
-  - [`enable-warnings-report`](#enable-warnings-report)
-- [Example usage](#example-usage)
-- [Additional resources](#additional-resources)
+- [`arduino/compile-sketches` action](#arduinocompile-sketches-action)
+  - [Table of contents](#table-of-contents)
+  - [Inputs](#inputs)
+    - [`cli-version`](#cli-version)
+    - [`fqbn`](#fqbn)
+    - [`platforms`](#platforms)
+      - [Supported platform sources:](#supported-platform-sources)
+        - [Boards Manager](#boards-manager)
+        - [Local path](#local-path)
+        - [Repository](#repository)
+        - [Archive download](#archive-download)
+    - [`libraries`](#libraries)
+      - [Supported library sources:](#supported-library-sources)
+        - [Library Manager](#library-manager)
+        - [Local path](#local-path-1)
+        - [Repository](#repository-1)
+        - [Archive download](#archive-download-1)
+    - [`sketch-paths`](#sketch-paths)
+    - [`cli-compile-flags`](#cli-compile-flags)
+    - [`verbose`](#verbose)
+    - [`sketches-report-path`](#sketches-report-path)
+    - [`github-token`](#github-token)
+    - [`enable-deltas-report`](#enable-deltas-report)
+      - [How it works](#how-it-works)
+    - [`enable-warnings-report`](#enable-warnings-report)
+  - [Example usage](#example-usage)
+  - [Additional resources](#additional-resources)
 
 <!-- tocstop -->
 
@@ -241,13 +243,39 @@ Set to `true` to cause the action to record the compiler warning count for each 
 ## Example usage
 
 ```yaml
-- uses: arduino/compile-sketches@v1
-  with:
-    fqbn: "arduino:avr:uno"
-    libraries: |
-      - name: Servo
-      - name: Stepper
-        version: 1.1.3
+# You will see this name in the Actions tab on GitHub
+name: Compile Sketches
+
+# Specify conditions for workflow to run
+on:
+  push: # push to main branch
+    branches:
+      -main
+  
+  pull_request: # PR to main branch
+    branches:
+      -main
+
+  workflow_dispatch: # Manually via button in the Actions tab
+
+
+# This workflow involves only one job to do, called compile-sketch
+jobs:
+  compile-sketch:
+    runs-on: ubuntu-latest # runner is latest Github-hosted Ubuntu
+    steps: # define what steps should be taken
+      # GA for checking out repo to runner -> https://github.com/actions/checkout
+      - uses: actions/checkout@v3
+      # GA for compiling sketches -> https://github.com/arduino/compile-sketches
+      - uses: arduino/compile-sketches@v1
+        with:
+          fqbn: "arduino:avr:uno" # specify fully qualified board name to compile sketches for
+          libraries: |
+            # load latest version of Servo library from arduino-libraries org
+            - name: Servo
+            # load version 1.1.3 of Stepper library 
+            - name: Stepper # 
+              version: 1.1.3
 ```
 
 ## Additional resources


### PR DESCRIPTION
## What is the problem?
- The current example under https://github.com/arduino/compile-sketches#example-usage is not a self contained example. This increases the barrier of entry for newcomers to the powerful arduino/compile-sketches GitHub Action
- As an example, I was under the impression that the checkout action was included as part of the arduino/compile-sketch GitHub action. However, checking out the repo is a required step prior to compiling the sketches.
- There is a helpful blogpost here: https://blog.arduino.cc/2021/04/09/test-your-arduino-projects-with-github-actions/. However, it has too much information leading to information overload.

## What This PR Changes
- I have elaborated upon the example to make it self contained. This includes:
     - Fully defining the `jobs:` entry, alongside the `on:` and `name:` items
     - Adding comments describing what the .yml file does, without assuming prior knowledge with GitHub Actions
     - Enabling the `workflow_dispatch:` option, so users can manually run the workflow

---

**Note:** I have a repo [here](https://github.com/aliphys/ArduinoBasicCompileSketch), where the .yml file is fully tested alongside example sketches.