### PR TITLE
Handle Arduino CLI 1.x `core list` command output data format

### DIFF
--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -1467,58 +1467,10 @@ class CompileSketches:
         final_original_interface_version = "0.17.0"  # Interface was changed in the next Arduino CLI release
 
         key_translation = {
-            "board details": {
-                "identification_pref": "identification_prefs",
-                "usbID": "usb_id",
-                "PID": "pid",
-                "VID": "vid",
-                "websiteURL": "website_url",
-                "archiveFileName": "archive_filename",
-                "propertiesId": "properties_id",
-                "toolsDependencies": "tools_dependencies",
-            },
-            "board list": {"FQBN": "fqbn", "VID": "vid", "PID": "pid"},
-            "board listall": {
-                "FQBN": "fqbn",
-                "Email": "email",
-                "ID": "id",
-                "Installed": "installed",
-                "Latest": "latest",
-                "Name": "name",
-                "Maintainer": "maintainer",
-                "Website": "website",
-            },
-            "board search": {
-                "FQBN": "fqbn",
-                "Email": "email",
-                "ID": "id",
-                "Installed": "installed",
-                "Latest": "latest",
-                "Name": "name",
-                "Maintainer": "maintainer",
-                "Website": "website",
-            },
             "core list": {
-                "Boards": "boards",
-                "Email": "email",
                 "ID": "id",
-                "Installed": "installed",
-                "Latest": "latest",
-                "Maintainer": "maintainer",
-                "Name": "name",
-                "Website": "website",
-            },
-            "core search": {
-                "Boards": "boards",
-                "Email": "email",
-                "ID": "id",
-                "Latest": "latest",
-                "Maintainer": "maintainer",
-                "Name": "name",
-                "Website": "website",
-            },
-            "lib deps": {"versionRequired": "version_required", "versionInstalled": "version_installed"},
-            "lib search": {"archivefilename": "archive_filename", "cachepath": "cache_path"},
+                "Installed": "installed"
+            }
         }
 
         if (

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -2884,6 +2884,21 @@ def test_create_sketches_report_file(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
+    "cli_version, data, assertion",
+    [
+        ("latest", {"platforms": [unittest.mock.sentinel.list_item]}, [unittest.mock.sentinel.list_item]),  # Non-semver
+        ("2.0.0", {"platforms": [unittest.mock.sentinel.list_item]}, [unittest.mock.sentinel.list_item]),  # >
+        ("1.0.0", {"platforms": [unittest.mock.sentinel.list_item]}, [unittest.mock.sentinel.list_item]),  # ==
+        ("0.1.2", [unittest.mock.sentinel.list_item], [unittest.mock.sentinel.list_item]),  # <
+    ],
+)
+def test_cli_core_list_platform_list(cli_version, data, assertion):
+    compile_sketches = get_compilesketches_object(cli_version=cli_version)
+
+    assert compile_sketches.cli_core_list_platform_list(data) == assertion
+
+
+@pytest.mark.parametrize(
     "cli_version, command, original_key, expected_key",
     [
         ("latest", "core list", "ID", "id"),  # Non-semver

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -2906,9 +2906,9 @@ def test_cli_core_list_platform_list(cli_version, data, assertion):
         ("0.17.0", "core list", "ID", "ID"),  # ==
         ("0.14.0-rc2", "core list", "ID", "ID"),  # <
         ("1.0.0", "foo", "ID", "ID"),  # Command has no translation
-        ("1.0.0", "core list", "foo", "foo"),
+        ("1.0.0", "core list", "foo", "foo"),  # Key has no translation
     ],
-)  # Key has no translation
+)
 def test_cli_json_key(cli_version, command, original_key, expected_key):
     compile_sketches = get_compilesketches_object(cli_version=cli_version)
 

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -2899,20 +2899,18 @@ def test_cli_core_list_platform_list(cli_version, data, assertion):
 
 
 @pytest.mark.parametrize(
-    "cli_version, command, original_key, expected_key",
+    "cli_version, command, key_name, expected_key",
     [
-        ("latest", "core list", "ID", "id"),  # Non-semver
-        ("1.0.0", "core list", "ID", "id"),  # >
-        ("0.17.0", "core list", "ID", "ID"),  # ==
-        ("0.14.0-rc2", "core list", "ID", "ID"),  # <
-        ("1.0.0", "foo", "ID", "ID"),  # Command has no translation
-        ("1.0.0", "core list", "foo", "foo"),  # Key has no translation
+        ("latest", "core list", "installed_version", "installed_version"),  # Non-semver
+        ("0.1.2", "core list", "installed_version", "Installed"),
+        ("0.17.1", "core list", "installed_version", "installed"),
+        ("1.2.3", "core list", "installed_version", "installed_version"),
     ],
 )
-def test_cli_json_key(cli_version, command, original_key, expected_key):
+def test_cli_json_key(cli_version, command, key_name, expected_key):
     compile_sketches = get_compilesketches_object(cli_version=cli_version)
 
-    assert compile_sketches.cli_json_key(command, original_key) == expected_key
+    assert compile_sketches.cli_json_key(command, key_name) == expected_key
 
 
 @pytest.mark.parametrize("verbose", ["true", "false"])


### PR DESCRIPTION
The action parses the output of the `arduino-cli core list --format json` command.

There were multiple breaking changes to the data format of that output in the 1.0.0 release of Arduino CLI. These caused runs of workflows using the action to fail if the workflow used a [platform dependency source](https://github.com/arduino/compile-sketches#supported-platform-sources) other than Boards Manager

```text
Traceback (most recent call last):
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 1717, in <module>
    main()  # pragma: no cover
    ^^^^^^
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 63, in main
    compile_sketches.compile_sketches()
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 219, in compile_sketches
    self.install_platforms()
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 334, in install_platforms
    self.install_platforms_from_path(platform_list=platform_list.path)
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 522, in install_platforms_from_path
    platform_installation_path = self.get_platform_installation_path(platform=platform)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 563, in get_platform_installation_path
    if installed_platform[self.cli_json_key("core list", "ID")] == platform[self.dependency_name_key]:
       ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```

## Change to overall data structure

https://arduino.github.io/arduino-cli/1.0/UPGRADING/#cli-changed-json-output-for-some-lib-core-config-board-and-sketch-commands

> - `arduino-cli core search --format json` and `arduino-cli core list --format json` results are now wrapped under `platforms` key
>
>  ```
>  { "platforms": [ {...}, {...} ] }
>  ```

This is fixed by https://github.com/arduino/compile-sketches/tree/40f6d20f1d0c2fcab12ef7ab9d30439ed1dc79f0

## `installed` key renamed to `installed_version`

https://arduino.github.io/arduino-cli/1.0/UPGRADING/#cli-core-list-and-core-search-changed-json-output

> ### CLI `core list` and `core search` changed JSON output.
>
>Below is an example of the response containing an object with all possible keys set.

```json
[...]

    "installed_version": "1.6.2",

[...]
```

This is fixed by https://github.com/arduino/compile-sketches/tree/26705b342943dcb94c56a93270d73c1be2e267ab

---

Fixes https://github.com/arduino/compile-sketches/issues/284