### PR TITLE
Generate standard code coverage report data file in `python:test` task

### DIFF
--- a/.github/workflows/test-python-poetry-task.yml
+++ b/.github/workflows/test-python-poetry-task.yml
@@ -65,9 +65,6 @@ jobs:
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
-    env:
-      COVERAGE_DATA_FILENAME: coverage.xml
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -98,14 +95,6 @@ jobs:
       - name: Display code coverage report
         run: task python:coverage-report
 
-      # codecov/codecov-action only makes the conversion if the `coverage` package is installed in the global runner
-      # environment
-      - name: Convert code coverage report to format required by Codecov
-        run: |
-          poetry run \
-            coverage xml \
-              -o "${{ github.workspace }}/${{ env.COVERAGE_DATA_FILENAME }}"
-
       # A token is used to avoid intermittent spurious job failures caused by rate limiting.
       - name: Set up Codecov upload token
         run: |
@@ -124,5 +113,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
-          file: ${{ env.COVERAGE_DATA_FILENAME }}
+          file: coverage.xml
           token: ${{ env.CODECOV_TOKEN }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -439,6 +439,9 @@ tasks:
             --source="{{.PYTHON_PROJECT_PATH}}" \
             --module \
               pytest "{{.PYTHON_PROJECT_PATH}}/tests"
+      - |
+        poetry run \
+          coverage xml
 
   # Make a temporary file named according to the passed TEMPLATE variable and print the path passed to stdout
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml


### PR DESCRIPTION
The `coverage run` command used to run the Python unit tests generates a `.coverage` data file. This file can not be consumed directly by the "codecov/codecov-action" GitHub Actions action that uploads the coverage data to Codecov. A separate `coverage xml` command must be used to generate the appropriate file.

Previously this `coverage xml` command was ran directly in the test runner GitHub Actions workflow. However, the file is also required by contributors running tests on their local machines in some cases (e.g., displaying coverage in the VS Code editor via the popular "Coverage Gutters" extension, which does not support the `.coverage` file). For this reason, it is best to move the `coverage xml` command invocation to the taskfile. The time required to generate the file is insignificant so it is added to the `python:test` task rather than adding a separate task the contributor would be required to run after the `python:test` task.