### PR TITLE
Disable Poetry "package mode"

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -420,7 +420,6 @@ tasks:
     cmds:
       - |
         poetry install \
-          --no-root \
           {{if .POETRY_GROUPS}} --only {{.POETRY_GROUPS}} {{end}}
 
   poetry:sync:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,7 @@
 line-length = 120
 
 [tool.poetry]
-name = "compilesketches"
-version = "0.0.0"
-description = ""
-authors = ["Arduino <info@arduino.cc>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "3.11.2"


### PR DESCRIPTION
The project's Python package dependencies are managed using the Poetry tool.

By default, Poetry is configured in "[package mode](https://python-poetry.org/docs/basic-usage/#operating-modes)", which is intended for use with projects that are a Python package. When Poetry is used in a project like this that is a standalone script, this configuration is in appropriate and has the following effects:

* `poetry install` command installs the project as a Python package in addition to the dependencies.
* [`name`](https://python-poetry.org/docs/pyproject/#name), [`version`](https://python-poetry.org/docs/pyproject/#version), [`description`](https://python-poetry.org/docs/pyproject/#description), and [`authors`](https://python-poetry.org/docs/pyproject/#authors) fields of the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file are required.

Installing the project as a package is completely inappropriate if the project is not a package, and may cause the command to fail with a cryptic error. This can be avoided by passing the [`--no-root`](https://python-poetry.org/docs/cli/#options-2:~:text=installation%2C%20use%20the-,%2D%2Dno%2Droot,-option.) flag to the [`install`](https://python-poetry.org/docs/cli/#install) command, but that increases the usage complexity and chance for user error.

Although metadata fields under the `tool.poetry` section of the `pyproject.toml` configuration file are important for a package, in a non-package project there are better ways to provide that information. Since Git tags are used for versioning, the presence of a `version` field is especially harmful since it means duplication of information and extra work for the project maintainer (and likelihood the metadata will not be kept updated).

This "package mode" can be disabled via the `pyproject.toml` configuration file, which causes Poetry to operate purely in the sole capacity in which it is used by this project: to manage dependencies.