### PR TITLE
Manage versioning of Poetry tool dependency

### DIFF
--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -71,12 +71,6 @@ jobs:
         with:
           python-version-file: pyproject.toml
 
-      - name: Install Poetry
-        run: |
-          pipx install \
-            --python "$(which python)" \
-            poetry
-
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
@@ -104,12 +98,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml
-
-      - name: Install Poetry
-        run: |
-          pipx install \
-            --python "$(which python)" \
-            poetry
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -99,12 +99,6 @@ jobs:
         with:
           python-version-file: pyproject.toml
 
-      - name: Install Poetry
-        run: |
-          pipx install \
-            --python "$(which python)" \
-            poetry
-
       - name: Install Task
         uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -53,12 +53,6 @@ jobs:
         with:
           python-version-file: pyproject.toml
 
-      - name: Install Poetry
-        run: |
-          pipx install \
-            --python "$(which python)" \
-            poetry
-
       - name: Install Task
         uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/test-python-poetry-task.yml
+++ b/.github/workflows/test-python-poetry-task.yml
@@ -75,12 +75,6 @@ jobs:
         with:
           python-version-file: pyproject.toml
 
-      - name: Install Poetry
-        run: |
-          pipx install \
-            --python "$(which python)" \
-            poetry
-
       - name: Install Task
         uses: arduino/setup-task@v2
         with:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -395,9 +395,21 @@ tasks:
           exit 1
         fi
       - |
+        if ! which yq &>/dev/null; then
+          echo "yq not found or not in PATH."
+          echo "Please install: https://github.com/mikefarah/yq/#install"
+          exit 1
+        fi
+      - |
         pipx install \
           --python "{{.PYTHON_PATH}}" \
-          poetry
+          "poetry==$( \
+            yq \
+              --input-format toml \
+              --output-format yaml \
+              '.tool.poetry.group.pipx.dependencies.poetry' \
+              < pyproject.toml
+          )"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -381,10 +381,30 @@ tasks:
           -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
           -d "{{.PROJECT_FOLDER}}/{{.INSTANCE_PATH}}"
 
+  poetry:install:
+    desc: Install Poetry
+    run: once
+    vars:
+      PYTHON_PATH:
+        sh: task utility:normalize-path RAW_PATH="$(which python)"
+    cmds:
+      - |
+        if ! which pipx &>/dev/null; then
+          echo "pipx not found or not in PATH."
+          echo "Please install: https://pipx.pypa.io/stable/installation/#installing-pipx"
+          exit 1
+        fi
+      - |
+        pipx install \
+          --python "{{.PYTHON_PATH}}" \
+          poetry
+
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:
     desc: Install dependencies managed by Poetry
     run: when_changed
+    deps:
+      - task: poetry:install
     cmds:
       - |
         poetry install \

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,13 @@ runs:
         # Install Poetry.
         pipx install \
           --python "$(which python)" \
-          poetry==1.4.0
+            "poetry==$( \
+              yq \
+                --input-format toml \
+                --output-format yaml \
+                '.tool.poetry.group.pipx.dependencies.poetry' \
+                < pyproject.toml
+            )"
 
         # Install Python dependencies.
         poetry install \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,14 @@ optional = true
 [tool.poetry.group.external.dependencies]
 pyserial = "3.5"
 
+# The dependencies in this group are installed using pipx; NOT Poetry. The use of a `poetry` section is a hack required
+# in order to be able to manage updates of these dependencies via Dependabot, as used for all other dependencies.
+[tool.poetry.group.pipx]
+optional = true
+
+[tool.poetry.group.pipx.dependencies]
+poetry = "1.4.0"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The project's Python package dependencies are managed by the [**Poetry**](https://python-poetry.org/) tool.

Previously, the version of **Poetry** was managed in two inconsistent and sub-ideal ways:

- The version used during execution of the action was hardcoded in the [action metadata file](https://github.com/arduino/compile-sketches/blob/main/action.yml).
- The version used locally by contributors and by the GitHub Actions workflows was not managed at all.

The first is problematic because there is no mechanism to facilitate updates, which means it will never be updated.

The second is problematic because some versions might be incompatible, or produce different results than the version used by the action.

The better solution is to take the same approach for managing the Poetry dependency as done for the project's other dependencies:

- Install a specific version of Poetry according to a single source of versioning data.
- Use the [**Dependabot**](https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) service to get automated update pull requests.

The logical place to define the [`poetry`](https://pypi.org/project/poetry/) package dependency version is in [pyproject.toml](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/), as is done for all direct Python package dependencies.

**Dependabot** recognizes two forms of dependency data in the `pyproject.toml` file:

- [Poetry](https://python-poetry.org/docs/pyproject/#dependencies-and-dependency-groups)
- [PEP 621](https://peps.python.org/pep-0621/)

Since **Poetry** can't be used to manage itself (it is instead installed using [**pipx**](https://pipx.pypa.io/stable/), the obvious approach would be to define the `poetry` dependency in a PEP 621 field in the file. However, this is not possible because if **Dependabot** finds **Poetry** data in `pyproject.toml`, it ignores the PEP 621 fields. So it is necessary to define the **Poetry** dependency in the **Poetry** fields of the file. A special [dependencies group](https://python-poetry.org/docs/pyproject/#dependencies-and-dependency-groups) is created for this purpose. That [group is configured as "optional"](https://python-poetry.org/docs/managing-dependencies/#optional-groups) so that it won't be installed redundantly by [`poetry install`](https://python-poetry.org/docs/cli/#install) commands.

Unfortunately **pipx** doesn't support using `pyproject.toml` as a dependency configuration file so it is necessary to generate the dependency argument in the **pipx** command by parsing the `project.toml` file. The [**yq**](https://mikefarah.gitbook.io/yq) tool is used for this purpose.