### PR TITLE
Handle inappropriate `null` output from `arduino-cli core list` when no platforms are installed

### DIFF
--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -1453,6 +1453,11 @@ class CompileSketches:
             or semver.Version.parse(version=self.cli_version).compare(other=first_new_interface_version) >= 0
         ):
             # cli_version is either "latest" (which will now always be >=1.0.0) or an explicit version >=1.0.0
+
+            # Workaround for https://github.com/arduino/arduino-cli/issues/2690
+            if data["platforms"] is None:
+                return []
+
             return data["platforms"]
 
         return data

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -2886,6 +2886,7 @@ def test_create_sketches_report_file(monkeypatch, tmp_path):
 @pytest.mark.parametrize(
     "cli_version, data, assertion",
     [
+        ("latest", {"platforms": None}, []),  # Non-semver
         ("latest", {"platforms": [unittest.mock.sentinel.list_item]}, [unittest.mock.sentinel.list_item]),  # Non-semver
         ("2.0.0", {"platforms": [unittest.mock.sentinel.list_item]}, [unittest.mock.sentinel.list_item]),  # >
         ("1.0.0", {"platforms": [unittest.mock.sentinel.list_item]}, [unittest.mock.sentinel.list_item]),  # ==


### PR DESCRIPTION
A regression was introduced in the 1.0.0 release of Arduino CLI (https://github.com/arduino/arduino-cli/issues/2690). When no platforms are installed, `arduino-cli core list --format json` now returns `null` instead of the appropriate value of an empty array.

Previously the code for parsing the output was written under the assumption of the logical behavior of the command always outputting an array, even if an empty array. This code could not correctly handle the output produced by Arduino CLI >=1.0.0, resulting in a spurious failure of the action (https://github.com/arduino/compile-sketches/issues/310):

```text
Traceback (most recent call last):
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 1709, in <module>
    main()  # pragma: no cover
    ^^^^^^
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 63, in main
    compile_sketches.compile_sketches()
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 219, in compile_sketches
    self.install_platforms()
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 337, in install_platforms
    self.install_platforms_from_repository(platform_list=platform_list.repository)
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 629, in install_platforms_from_repository
    destination_path = self.get_platform_installation_path(platform=platform)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 562, in get_platform_installation_path
    for installed_platform in installed_platform_list:
TypeError: 'NoneType' object is not iterable
```

In order to work around the Arduino CLI bug, code is added to handle the case where the value is `null` (`None` when converted to a Python data type) instead of an array.

---

Fixes https://github.com/arduino/compile-sketches/issues/310