### PR TITLE
Use `engines.node` as source of version data for "actions/setup-node" action

### DIFF
--- a/.github/workflows/check-action-metadata-task.yml
+++ b/.github/workflows/check-action-metadata-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-action-metadata-task.md
 name: Check Action Metadata
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   create:
@@ -67,7 +63,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-markdown-task.md
 name: Check Markdown
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   create:
@@ -77,7 +73,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Initialize markdownlint-cli problem matcher
         uses: xt0rted/markdownlint-problem-matcher@v3
@@ -105,7 +101,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-npm-task.md
 name: Check npm
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   create:
@@ -72,7 +68,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -104,7 +100,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-prettier-formatting-task.md
 name: Check Prettier Formatting
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   create:
@@ -245,7 +241,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-taskfiles.md
 name: Check Taskfiles
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   create:
@@ -73,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Download JSON schema for Taskfiles
         id: download-schema

--- a/.github/workflows/check-toc-task.yml
+++ b/.github/workflows/check-toc-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-toc-task.md
 name: Check ToC
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   create:
@@ -75,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-workflows-task.md
 name: Check Workflows
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
@@ -38,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -1,12 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels-npm.md
 name: Sync Labels
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-  CONFIGURATIONS_FOLDER: .github/label-configuration-files
-  CONFIGURATIONS_ARTIFACT_PREFIX: label-configuration-file-
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
@@ -27,6 +21,10 @@ on:
   workflow_dispatch:
   repository_dispatch:
 
+env:
+  CONFIGURATIONS_FOLDER: .github/label-configuration-files
+  CONFIGURATIONS_ARTIFACT_PREFIX: label-configuration-file-
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -40,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Download JSON schema for labels configuration file
         id: download-schema
@@ -139,7 +137,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Merge label configuration files
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "markdown-toc": "1.2.0",
         "markdownlint-cli": "0.37.0",
         "prettier": "3.6.2"
+      },
+      "engines": {
+        "node": "16.x"
       }
     },
     "node_modules/@financial-times/origami-service-makefile": {

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "markdown-toc": "1.2.0",
     "markdownlint-cli": "0.37.0",
     "prettier": "3.6.2"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
A single standardized version of Node.js is used for all development work in this repository, both by contributors and the automated validation systems.

The **actions/setup-node** GitHub Actions action is used to set up Node.js in the GitHub Actions runner machine.

The action supports obtaining the Node.js version to set up from the `engines.node` key of the `package.json` file:

https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file

This allows us to define the standardized version of Node.js for use by project contributors in a single place rather than having to maintain multiple instances of that data.
