### PR TITLE
Bump project Node.js version to 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "prettier": "3.6.2"
       },
       "engines": {
-        "node": "16.x"
+        "node": "22.x"
       }
     },
     "node_modules/@financial-times/origami-service-makefile": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "prettier": "3.6.2"
   },
   "engines": {
-    "node": "16.x"
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
npm package-based tools are used for various development and maintenance operations for this project. In order to ensure these operations work as expected, the project is configured for a specific major version of Node.js to be used by the infrastructure systems and collaborators.

The standard Node.js version for Arduino Tooling projects is now 22.