### PR TITLE
Configure npm to enforce standard project Node.js version

### DIFF
--- a/.github/workflows/check-action-metadata-task.yml
+++ b/.github/workflows/check-action-metadata-task.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/check-action-metadata-task.ya?ml"
       - "action.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
@@ -15,6 +16,7 @@ on:
     paths:
       - ".github/workflows/check-action-metadata-task.ya?ml"
       - "action.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/check-markdown-task.ya?ml"
       - ".markdown-link-check.json"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
@@ -20,6 +21,7 @@ on:
     paths:
       - ".github/workflows/check-markdown-task.ya?ml"
       - ".markdown-link-check.json"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -7,12 +7,14 @@ on:
   push:
     paths:
       - ".github/workflows/check-npm-task.ya?ml"
+      - "**/.npmrc"
       - "**/package.json"
       - "**/package-lock.json"
       - "Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-npm-task.ya?ml"
+      - "**/.npmrc"
       - "**/package.json"
       - "**/package-lock.json"
       - "Taskfile.ya?ml"

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -7,6 +7,7 @@ on:
   push:
     paths:
       - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - ".npmrc"
       - "Taskfile.ya?ml"
       - "**/.prettierignore"
       - "**/.prettierrc*"
@@ -103,6 +104,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - ".npmrc"
       - "Taskfile.ya?ml"
       - "**/.prettierignore"
       - "**/.prettierrc*"

--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -7,12 +7,14 @@ on:
   push:
     paths:
       - ".github/workflows/check-taskfiles.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "**/Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-taskfiles.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "**/Taskfile.ya?ml"

--- a/.github/workflows/check-toc-task.yml
+++ b/.github/workflows/check-toc-task.yml
@@ -7,12 +7,14 @@ on:
   push:
     paths:
       - ".github/workflows/check-toc-task.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "README.md"
   pull_request:
     paths:
       - ".github/workflows/check-toc-task.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "README.md"

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -6,12 +6,14 @@ on:
   push:
     paths:
       - ".github/workflows/*.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/*.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - ".github/workflows/sync-labels-npm.ya?ml"
       - ".github/label-configuration-files/*.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
   pull_request:
     paths:
       - ".github/workflows/sync-labels-npm.ya?ml"
       - ".github/label-configuration-files/*.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
   schedule:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm/.npmrc
+# See: https://docs.npmjs.com/cli/configuring-npm/npmrc
+
+engine-strict=true


### PR DESCRIPTION
This will produce an error if a contributor attempts to run an npm command in the project using an unsupported version of Node.js.