### PR TITLE
Upstreaming changes used in ArduinoCore-zephyr

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -8,6 +8,8 @@
     "^LICENSE\\.txt$",
     "^poetry\\.lock$",
     "\\.py$",
+    "^compilesketches[/\\\\]tests[/\\\\]testdata[/\\\\]test_get_issues_from_output[/\\\\]has-issues\\.txt$",
+    "^compilesketches[/\\\\]tests[/\\\\]testdata[/\\\\]test_get_issues_from_output[/\\\\]no-issues\\.txt$",
     "^compilesketches[/\\\\]tests[/\\\\]testdata[/\\\\]test_get_warning_count_from_output[/\\\\]has-warnings\\.txt$",
     "^compilesketches[/\\\\]tests[/\\\\]testdata[/\\\\]test_get_warning_count_from_output[/\\\\]no-warnings\\.txt$"
   ]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This action checks whether [Arduino](https://www.arduino.cc/) sketches compile a
   - [`enable-deltas-report`](#enable-deltas-report)
     - [How it works](#how-it-works)
   - [`enable-warnings-report`](#enable-warnings-report)
+  - [`enable-issues-report`](#enable-issues-report)
 - [Example usage](#example-usage)
 - [Additional resources](#additional-resources)
 
@@ -236,6 +237,12 @@ Dependencies defined via the [`libraries`](#libraries) or [`platforms`](#platfor
 ### `enable-warnings-report`
 
 Set to `true` to cause the action to record the compiler warning count for each sketch compilation in the sketches report.
+
+**Default**: `false`
+
+### `enable-issues-report`
+
+Set to `true` to cause the action to record lines that match standard compiler or linker warning/error patterns for each sketch compilation in the sketches report.
 
 **Default**: `false`
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This action checks whether [Arduino](https://www.arduino.cc/) sketches compile a
     - [How it works](#how-it-works)
   - [`enable-warnings-report`](#enable-warnings-report)
   - [`enable-issues-report`](#enable-issues-report)
+  - [`fail-on-build-error`](#fail-on-build-error)
 - [Example usage](#example-usage)
 - [Additional resources](#additional-resources)
 
@@ -245,6 +246,12 @@ Set to `true` to cause the action to record the compiler warning count for each 
 Set to `true` to cause the action to record lines that match standard compiler or linker warning/error patterns for each sketch compilation in the sketches report.
 
 **Default**: `false`
+
+### `fail-on-build-error`
+
+Set to `false` to cause the action to ignore the result of sketch build operations and always return success to the workflow. The sketches report will still be produced and can be analyzed without automatically failing the workflow.
+
+**Default**: `true`
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,12 @@ inputs:
       report
     default: "false"
     required: true
+  enable-issues-report:
+    description: >-
+      Set to true to cause the action to record the compiler messages (warnings
+      and errors) for each sketch compilation in the sketches report
+    default: "false"
+    required: false
 
 runs:
   using: composite
@@ -129,6 +135,7 @@ runs:
         INPUT_GITHUB-TOKEN: ${{ inputs.github-token }}
         INPUT_ENABLE-DELTAS-REPORT: ${{ inputs.enable-deltas-report }}
         INPUT_ENABLE-WARNINGS-REPORT: ${{ inputs.enable-warnings-report }}
+        INPUT_ENABLE-ISSUES-REPORT: ${{ inputs.enable-issues-report }}
         INPUT_SKETCHES-REPORT-PATH: ${{ inputs.sketches-report-path }}
       working-directory: ${{ github.action_path }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,12 @@ inputs:
       and errors) for each sketch compilation in the sketches report
     default: "false"
     required: false
+  fail-on-build-error:
+    description: >-
+      Set to false to cause the action to never return a failure code, even if
+      an error is detected when building sketches.
+    default: "true"
+    required: false
 
 runs:
   using: composite
@@ -136,6 +142,7 @@ runs:
         INPUT_ENABLE-DELTAS-REPORT: ${{ inputs.enable-deltas-report }}
         INPUT_ENABLE-WARNINGS-REPORT: ${{ inputs.enable-warnings-report }}
         INPUT_ENABLE-ISSUES-REPORT: ${{ inputs.enable-issues-report }}
+        INPUT_FAIL-ON-BUILD-ERROR: ${{ inputs.fail-on-build-error }}
         INPUT_SKETCHES-REPORT-PATH: ${{ inputs.sketches-report-path }}
       working-directory: ${{ github.action_path }}
       run: |

--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -1721,14 +1721,21 @@ def get_archive_root_path(archive_extract_path):
 
 def get_head_commit_hash():
     """Return the head commit's hash."""
+    with open(file=os.environ["GITHUB_EVENT_PATH"]) as github_event_file:
+        event = json.load(github_event_file)
+
     if os.environ["GITHUB_EVENT_NAME"] == "pull_request":
         # When the workflow is triggered by a pull_request event, actions/checkout checks out the hypothetical merge
         # commit GitHub automatically generates for PRs. The user will expect the report to show the hash of the head
         # commit of the PR, not of this hidden merge commit. So it's necessary it get it from GITHUB_EVENT_PATH instead
         # of git rev-parse HEAD.
-        with open(file=os.environ["GITHUB_EVENT_PATH"]) as github_event_file:
-            commit_hash = json.load(github_event_file)["pull_request"]["head"]["sha"]
+        commit_hash = event["pull_request"]["head"]["sha"]
+    elif os.environ["GITHUB_EVENT_NAME"] == "push":
+        # For push events, the head ref is in the 'after' field of the event payload, so just use it.
+        # Avoids the need to have the full git repo available.
+        commit_hash = event["after"]
     else:
+        # For other event types, just get the head commit hash from the git repository.
         repository = git.Repo(path=os.environ["GITHUB_WORKSPACE"])
         commit_hash = repository.git.rev_parse("HEAD")
 

--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -953,7 +953,7 @@ class CompileSketches:
             output = compilation_data.stdout
 
         if not CompilationResult.success:
-            print("::error::Compilation failed")
+            print("::error::Compilation failed:", path_relative_to_workspace(path=sketch_path))
         else:
             time_summary = ""
             if diff_time > 60:

--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -57,6 +57,7 @@ def main():
         github_token=os.environ["INPUT_GITHUB-TOKEN"],
         enable_deltas_report=os.environ["INPUT_ENABLE-DELTAS-REPORT"],
         enable_warnings_report=os.environ["INPUT_ENABLE-WARNINGS-REPORT"],
+        enable_issues_report=os.environ["INPUT_ENABLE-ISSUES-REPORT"],
         sketches_report_path=os.environ["INPUT_SKETCHES-REPORT-PATH"],
     )
 
@@ -80,6 +81,8 @@ class CompileSketches:
     enable_deltas_report -- set to "true" to cause the action to determine the change in memory usage
                                  ("true", "false")
     enable_warnings_report -- set to "true" to cause the action to add compiler warning count to the sketches report
+                                 ("true", "false")
+    enable_issues_report -- set to "true" to cause the action to add compiler warning and error messages to the sketches report
                                  ("true", "false")
     sketches_report_path -- folder to save the sketches report to
     """
@@ -108,6 +111,7 @@ class CompileSketches:
         compilation_success = "compilation_success"
         sizes = "sizes"
         warnings = "warnings"
+        issues = "issues"
         name = "name"
         absolute = "absolute"
         relative = "relative"
@@ -138,6 +142,7 @@ class CompileSketches:
         github_token,
         enable_deltas_report,
         enable_warnings_report,
+        enable_issues_report,
         sketches_report_path,
     ):
         """Process, store, and validate the action's inputs."""
@@ -170,6 +175,7 @@ class CompileSketches:
             sys.exit(1)
 
         self.enable_warnings_report = parse_boolean_input(boolean_input=enable_warnings_report)
+        self.enable_issues_report = parse_boolean_input(boolean_input=enable_issues_report)
         # The enable-deltas-report input has a default value so it should always be either True or False
         if self.enable_warnings_report is None:
             print("::error::Invalid value for enable-warnings-report input")
@@ -229,7 +235,9 @@ class CompileSketches:
         for sketch in sketch_list:
             # It's necessary to clear the cache between each compilation to get a true compiler warning count, otherwise
             # only the first sketch compilation's warning count would reflect warnings from cached code
-            compilation_result = self.compile_sketch(sketch_path=sketch, clean_build_cache=self.enable_warnings_report)
+            compilation_result = self.compile_sketch(
+                sketch_path=sketch, clean_build_cache=self.enable_warnings_report or self.enable_issues_report
+            )
             if not compilation_result.success:
                 all_compilations_successful = False
 
@@ -1006,6 +1014,8 @@ class CompileSketches:
             sketch_report[self.ReportKeys.warnings] = self.get_warnings_report(
                 current_warnings=current_warning_count, previous_warnings=previous_warning_count
             )
+        if self.enable_issues_report:
+            sketch_report[self.ReportKeys.issues] = self.get_issues_from_output(compilation_result=compilation_result)
 
         return sketch_report
 
@@ -1107,6 +1117,22 @@ class CompileSketches:
             )
 
         return size_data
+
+    def get_issues_from_output(self, compilation_result):
+        """Parse the stdout from the compilation process and return all
+        compiler warning or error messages.
+
+        Keyword arguments:
+        compilation_result -- object returned by compile_sketch()
+        """
+        issues = []
+        compiler_issue_regex = re.compile(r"(:[0-9]+:[0-9]+|^\S+): (fatal )?(warning|error):", re.IGNORECASE)
+        linker_issue_regex = re.compile(r": undefined reference to|\([1-9][0-9][0-9]+%\).*Maximum")
+        for line in compilation_result.output.splitlines():
+            if compiler_issue_regex.search(line) or linker_issue_regex.search(line):
+                issues.append(line)
+
+        return issues
 
     def get_warning_count_from_output(self, compilation_result):
         """Parse the stdout from the compilation process and return the number of compiler warnings. Since the

--- a/compilesketches/compilesketches.py
+++ b/compilesketches/compilesketches.py
@@ -58,6 +58,7 @@ def main():
         enable_deltas_report=os.environ["INPUT_ENABLE-DELTAS-REPORT"],
         enable_warnings_report=os.environ["INPUT_ENABLE-WARNINGS-REPORT"],
         enable_issues_report=os.environ["INPUT_ENABLE-ISSUES-REPORT"],
+        fail_on_build_error=os.environ["INPUT_FAIL-ON-BUILD-ERROR"],
         sketches_report_path=os.environ["INPUT_SKETCHES-REPORT-PATH"],
     )
 
@@ -143,6 +144,7 @@ class CompileSketches:
         enable_deltas_report,
         enable_warnings_report,
         enable_issues_report,
+        fail_on_build_error,
         sketches_report_path,
     ):
         """Process, store, and validate the action's inputs."""
@@ -176,6 +178,7 @@ class CompileSketches:
 
         self.enable_warnings_report = parse_boolean_input(boolean_input=enable_warnings_report)
         self.enable_issues_report = parse_boolean_input(boolean_input=enable_issues_report)
+        self.fail_on_build_error = parse_boolean_input(boolean_input=fail_on_build_error)
         # The enable-deltas-report input has a default value so it should always be either True or False
         if self.enable_warnings_report is None:
             print("::error::Invalid value for enable-warnings-report input")
@@ -250,7 +253,8 @@ class CompileSketches:
 
         if not all_compilations_successful:
             print("::error::One or more compilations failed")
-            sys.exit(1)
+            if self.fail_on_build_error:
+                sys.exit(1)
 
     def install_arduino_cli(self):
         """Install Arduino CLI."""

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -3260,7 +3260,12 @@ def test_clone_repository(tmp_path, git_ref):
 
 
 @pytest.mark.parametrize(
-    "github_event, expected_hash", [("pull_request", "pull_request-head-sha"), ("push", "push-head-sha")]
+    "github_event, expected_hash",
+    [
+        ("pull_request", "pull_request-head-sha"),
+        ("push", "push-head-sha"),
+        ("workflow_dispatch", "workflow_dispatch-head-sha"),
+    ],
 )
 def test_get_head_commit_hash(monkeypatch, mocker, github_event, expected_hash):
     # Stub
@@ -3275,6 +3280,6 @@ def test_get_head_commit_hash(monkeypatch, mocker, github_event, expected_hash):
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(test_data_path.joinpath("githubevent.json")))
 
     mocker.patch("git.Repo", autospec=True, return_value=Repo())
-    mocker.patch.object(Repo, "rev_parse", return_value="push-head-sha")
+    mocker.patch.object(Repo, "rev_parse", return_value="workflow_dispatch-head-sha")
 
     assert compilesketches.get_head_commit_hash() == expected_hash

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -1600,7 +1600,9 @@ def test_compile_sketch(capsys, mocker, clean_build_cache, returncode, expected_
         + "::endgroup::"
     )
     if not expected_success:
-        expected_stdout += "\n::error::Compilation failed"
+        expected_stdout += "\n::error::Compilation failed: " + str(
+            compilesketches.path_relative_to_workspace(path=sketch_path)
+        )
     else:
         expected_stdout += "\nCompilation time elapsed: 0s"
     assert capsys.readouterr().out.strip() == expected_stdout

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -32,6 +32,7 @@ def get_compilesketches_object(
     deltas_base_ref="foodeltasbaseref",
     enable_deltas_report="false",
     enable_warnings_report="false",
+    enable_issues_report="false",
     sketches_report_path="foo report_folder_name",
 ):
     with unittest.mock.patch(
@@ -48,6 +49,7 @@ def get_compilesketches_object(
             github_token=github_token,
             enable_deltas_report=enable_deltas_report,
             enable_warnings_report=enable_warnings_report,
+            enable_issues_report=enable_issues_report,
             sketches_report_path=sketches_report_path,
         )
 
@@ -105,6 +107,7 @@ def setup_action_inputs(monkeypatch):
         enable_size_deltas_report = "FooEnableSizeDeltasReport"
         enable_deltas_report = "FooEnableDeltasReport"
         enable_warnings_report = "FooEnableWarningsReport"
+        enable_issues_report = "FooEnableIssuesReport"
         sketches_report_path = "FooSketchesReportPath"
         size_deltas_report_folder_name = "FooSizeDeltasReportFolderName"
 
@@ -118,6 +121,7 @@ def setup_action_inputs(monkeypatch):
     monkeypatch.setenv("INPUT_GITHUB-TOKEN", ActionInputs.github_token)
     monkeypatch.setenv("INPUT_ENABLE-DELTAS-REPORT", ActionInputs.enable_deltas_report)
     monkeypatch.setenv("INPUT_ENABLE-WARNINGS-REPORT", ActionInputs.enable_warnings_report)
+    monkeypatch.setenv("INPUT_ENABLE-ISSUES-REPORT", ActionInputs.enable_issues_report)
     monkeypatch.setenv("INPUT_SKETCHES-REPORT-PATH", ActionInputs.sketches_report_path)
 
     return ActionInputs()
@@ -245,6 +249,7 @@ def test_main(mocker, setup_action_inputs):
         github_token=setup_action_inputs.github_token,
         enable_deltas_report=setup_action_inputs.enable_deltas_report,
         enable_warnings_report=setup_action_inputs.enable_warnings_report,
+        enable_issues_report=setup_action_inputs.enable_issues_report,
         sketches_report_path=setup_action_inputs.sketches_report_path,
     )
 
@@ -269,6 +274,7 @@ def test_compilesketches():
     expected_deltas_base_ref = unittest.mock.sentinel.deltas_base_ref
     enable_deltas_report = "true"
     enable_warnings_report = "true"
+    enable_issues_report = "false"
     sketches_report_path = "FooSketchesReportFolder"
 
     with unittest.mock.patch(
@@ -285,6 +291,7 @@ def test_compilesketches():
             github_token=github_token,
             enable_deltas_report=enable_deltas_report,
             enable_warnings_report=enable_warnings_report,
+            enable_issues_report=enable_issues_report,
             sketches_report_path=sketches_report_path,
         )
 
@@ -299,6 +306,7 @@ def test_compilesketches():
     assert compile_sketches.deltas_base_ref == expected_deltas_base_ref
     assert compile_sketches.enable_deltas_report is True
     assert compile_sketches.enable_warnings_report is True
+    assert compile_sketches.enable_issues_report is False
     assert compile_sketches.sketches_report_path == pathlib.PurePath(sketches_report_path)
 
     assert get_compilesketches_object(cli_compile_flags="").cli_compile_flags is None
@@ -1722,6 +1730,49 @@ def test_get_sketch_report(mocker, enable_warnings_report, do_deltas_report):
     assert sketch_report == expected_sketch_report
 
 
+@pytest.mark.parametrize("enable_issues_report", ["true", "false"])
+def test_get_sketch_report_issues_report(mocker, enable_issues_report):
+    sketch = "/foo/SketchName"
+    success = unittest.mock.sentinel.success
+
+    class CompilationResult:
+        def __init__(self, sketch_input, success_input):
+            self.sketch = sketch_input
+            self.success = success_input
+
+    compilation_result = CompilationResult(sketch_input=sketch, success_input=success)
+
+    sizes_report = unittest.mock.sentinel.sizes_report
+    issues_report = unittest.mock.sentinel.issues_report
+
+    compile_sketches = get_compilesketches_object(
+        enable_warnings_report="false",
+        enable_issues_report=enable_issues_report,
+    )
+
+    mocker.patch(
+        "compilesketches.CompileSketches.get_sizes_from_output",
+        autospec=True,
+        return_value=unittest.mock.sentinel.sizes,
+    )
+    mocker.patch("compilesketches.CompileSketches.do_deltas_report", autospec=True, return_value=False)
+    mocker.patch("compilesketches.CompileSketches.get_sizes_report", autospec=True, return_value=sizes_report)
+    mocker.patch("compilesketches.CompileSketches.get_issues_from_output", autospec=True, return_value=issues_report)
+
+    sketch_report = compile_sketches.get_sketch_report(compilation_result=compilation_result)
+
+    if enable_issues_report == "true":
+        # noinspection PyUnresolvedReferences
+        compile_sketches.get_issues_from_output.assert_called_once_with(
+            compile_sketches, compilation_result=compilation_result
+        )
+        assert compile_sketches.ReportKeys.issues in sketch_report
+        assert sketch_report[compile_sketches.ReportKeys.issues] == issues_report
+    else:
+        compile_sketches.get_issues_from_output.assert_not_called()
+        assert compile_sketches.ReportKeys.issues not in sketch_report
+
+
 @pytest.mark.parametrize(
     "compilation_success, compilation_output, flash, maximum_flash, relative_flash, ram, maximum_ram, relative_ram",
     [
@@ -1974,6 +2025,37 @@ def test_get_warning_count_from_output(compilation_success, test_compilation_out
             output = test_compilation_output_file.read()
 
     assert compile_sketches.get_warning_count_from_output(CompilationResult()) == expected_warning_count
+
+
+@pytest.mark.parametrize(
+    "test_compilation_output_filename, expected_issues",
+    [
+        (
+            pathlib.Path("test_get_issues_from_output", "has-issues.txt"),
+            [
+                "/path/to/lib.h:42:5: warning: unused variable 'counter' [-Wunused-variable]",
+                "/path/to/lib.h:55:10: error: 'foo' was not declared in this scope",
+                "/path/to/lib.h:67:3: fatal error: missing.h: No such file or directory",
+                "/path/to/sketch/sketch.ino:100:15: warning: comparison between signed and unsigned [-Wsign-compare]",
+                "sketch.ino: error: expected ';' before '}' token",
+                "/path/to/lib.a(lib.o): undefined reference to `some_function()'",
+                "collect2: error: ld returned 1 exit status",
+            ],
+        ),
+        (pathlib.Path("test_get_issues_from_output", "no-issues.txt"), []),
+    ],
+)
+def test_get_issues_from_output(test_compilation_output_filename, expected_issues):
+    compile_sketches = get_compilesketches_object()
+
+    with open(
+        file=test_data_path.joinpath(test_compilation_output_filename), mode="r", encoding="utf-8"
+    ) as test_compilation_output_file:
+
+        class CompilationResult:
+            output = test_compilation_output_file.read()
+
+    assert compile_sketches.get_issues_from_output(CompilationResult()) == expected_issues
 
 
 @pytest.mark.parametrize(

--- a/compilesketches/tests/test_compilesketches.py
+++ b/compilesketches/tests/test_compilesketches.py
@@ -33,6 +33,7 @@ def get_compilesketches_object(
     enable_deltas_report="false",
     enable_warnings_report="false",
     enable_issues_report="false",
+    fail_on_build_error="false",
     sketches_report_path="foo report_folder_name",
 ):
     with unittest.mock.patch(
@@ -50,6 +51,7 @@ def get_compilesketches_object(
             enable_deltas_report=enable_deltas_report,
             enable_warnings_report=enable_warnings_report,
             enable_issues_report=enable_issues_report,
+            fail_on_build_error=fail_on_build_error,
             sketches_report_path=sketches_report_path,
         )
 
@@ -108,6 +110,7 @@ def setup_action_inputs(monkeypatch):
         enable_deltas_report = "FooEnableDeltasReport"
         enable_warnings_report = "FooEnableWarningsReport"
         enable_issues_report = "FooEnableIssuesReport"
+        fail_on_build_error = "FooAlwaysSucceed"
         sketches_report_path = "FooSketchesReportPath"
         size_deltas_report_folder_name = "FooSizeDeltasReportFolderName"
 
@@ -122,6 +125,7 @@ def setup_action_inputs(monkeypatch):
     monkeypatch.setenv("INPUT_ENABLE-DELTAS-REPORT", ActionInputs.enable_deltas_report)
     monkeypatch.setenv("INPUT_ENABLE-WARNINGS-REPORT", ActionInputs.enable_warnings_report)
     monkeypatch.setenv("INPUT_ENABLE-ISSUES-REPORT", ActionInputs.enable_issues_report)
+    monkeypatch.setenv("INPUT_FAIL-ON-BUILD-ERROR", ActionInputs.fail_on_build_error)
     monkeypatch.setenv("INPUT_SKETCHES-REPORT-PATH", ActionInputs.sketches_report_path)
 
     return ActionInputs()
@@ -250,6 +254,7 @@ def test_main(mocker, setup_action_inputs):
         enable_deltas_report=setup_action_inputs.enable_deltas_report,
         enable_warnings_report=setup_action_inputs.enable_warnings_report,
         enable_issues_report=setup_action_inputs.enable_issues_report,
+        fail_on_build_error=setup_action_inputs.fail_on_build_error,
         sketches_report_path=setup_action_inputs.sketches_report_path,
     )
 
@@ -275,6 +280,7 @@ def test_compilesketches():
     enable_deltas_report = "true"
     enable_warnings_report = "true"
     enable_issues_report = "false"
+    fail_on_build_error = "false"
     sketches_report_path = "FooSketchesReportFolder"
 
     with unittest.mock.patch(
@@ -292,6 +298,7 @@ def test_compilesketches():
             enable_deltas_report=enable_deltas_report,
             enable_warnings_report=enable_warnings_report,
             enable_issues_report=enable_issues_report,
+            fail_on_build_error=fail_on_build_error,
             sketches_report_path=sketches_report_path,
         )
 
@@ -307,6 +314,7 @@ def test_compilesketches():
     assert compile_sketches.enable_deltas_report is True
     assert compile_sketches.enable_warnings_report is True
     assert compile_sketches.enable_issues_report is False
+    assert compile_sketches.fail_on_build_error is False
     assert compile_sketches.sketches_report_path == pathlib.PurePath(sketches_report_path)
 
     assert get_compilesketches_object(cli_compile_flags="").cli_compile_flags is None
@@ -408,6 +416,7 @@ def test_get_parent_commit_ref(mocker):
     git.Repo.assert_called_once_with(path=os.environ["GITHUB_WORKSPACE"])
 
 
+@pytest.mark.parametrize("fail_on_build_error", ["true", "false"])
 @pytest.mark.parametrize("enable_warnings_report, expected_clean_build_cache", [("true", True), ("false", False)])
 @pytest.mark.parametrize(
     "compilation_success_list, expected_success",
@@ -419,7 +428,12 @@ def test_get_parent_commit_ref(mocker):
     ],
 )
 def test_compile_sketches(
-    mocker, enable_warnings_report, expected_clean_build_cache, compilation_success_list, expected_success
+    mocker,
+    fail_on_build_error,
+    enable_warnings_report,
+    expected_clean_build_cache,
+    compilation_success_list,
+    expected_success,
 ):
     sketch_list = [unittest.mock.sentinel.sketch1, unittest.mock.sentinel.sketch2, unittest.mock.sentinel.sketch3]
 
@@ -429,7 +443,10 @@ def test_compile_sketches(
     sketch_report = unittest.mock.sentinel.sketch_report
     sketches_report = unittest.mock.sentinel.sketch_report_from_sketches_report
 
-    compile_sketches = get_compilesketches_object(enable_warnings_report=enable_warnings_report)
+    compile_sketches = get_compilesketches_object(
+        enable_warnings_report=enable_warnings_report,
+        fail_on_build_error=fail_on_build_error,
+    )
 
     mocker.patch("compilesketches.CompileSketches.install_arduino_cli", autospec=True)
     mocker.patch("compilesketches.CompileSketches.install_platforms", autospec=True)
@@ -440,7 +457,7 @@ def test_compile_sketches(
     mocker.patch("compilesketches.CompileSketches.get_sketches_report", autospec=True, return_value=sketches_report)
     mocker.patch("compilesketches.CompileSketches.create_sketches_report_file", autospec=True)
 
-    if expected_success:
+    if expected_success or fail_on_build_error == "false":
         compile_sketches.compile_sketches()
     else:
         with pytest.raises(expected_exception=SystemExit, match="1"):

--- a/compilesketches/tests/testdata/githubevent.json
+++ b/compilesketches/tests/testdata/githubevent.json
@@ -1,4 +1,5 @@
 {
+  "after": "push-head-sha",
   "pull_request": {
     "head": {
       "sha": "pull_request-head-sha"

--- a/compilesketches/tests/testdata/test_get_issues_from_output/has-issues.txt
+++ b/compilesketches/tests/testdata/test_get_issues_from_output/has-issues.txt
@@ -1,0 +1,21 @@
+In file included from /path/to/lib.h:10:0,
+                 from /path/to/sketch/sketch.ino:1:
+/path/to/lib.h:42:5: warning: unused variable 'counter' [-Wunused-variable]
+     int counter = 0;
+         ^~~~~~~
+/path/to/lib.h:42:5: note: declared here
+/path/to/lib.h:55:10: error: 'foo' was not declared in this scope
+     foo();
+     ^~~
+/path/to/lib.h:67:3: fatal error: missing.h: No such file or directory
+ #include "missing.h"
+   ^~~~~~~~~~~~
+/path/to/sketch/sketch.ino:100:15: warning: comparison between signed and unsigned [-Wsign-compare]
+     if (x < size) {
+               ^~~~
+sketch.ino: In function 'void setup()':
+sketch.ino: error: expected ';' before '}' token
+/path/to/lib.a(lib.o): undefined reference to `some_function()'
+collect2: error: ld returned 1 exit status
+Sketch uses 1234 bytes (4%) of program storage space. Maximum is 32256 bytes.
+Global variables use 200 bytes (9%) of dynamic memory, leaving 1848 bytes for local variables. Maximum is 2048 bytes.

--- a/compilesketches/tests/testdata/test_get_issues_from_output/no-issues.txt
+++ b/compilesketches/tests/testdata/test_get_issues_from_output/no-issues.txt
@@ -1,0 +1,2 @@
+Sketch uses 1234 bytes (4%) of program storage space. Maximum is 32256 bytes.
+Global variables use 200 bytes (9%) of dynamic memory, leaving 1848 bytes for local variables. Maximum is 2048 bytes.


### PR DESCRIPTION
This PR adds four new features to the `compile-sketches` action; each one in a separate commit with its own tests.

These changes have been in use in the [arduino/ArduinoCore-zephyr](https://github.com/arduino/ArduinoCore-zephyr) repo for over a year now, but I never found the time to add the tests; finally got Copilot to do the dirty work (supervised). 

---

### New input: `enable-issues-report`

A new boolean input that causes the action to record all compiler and linker warning/error messages for each sketch compilation in the sketches report.

This complements the existing `enable-warnings-report` (which records warning _counts_) by capturing the full text of each diagnostic message, making it possible for downstream report consumers to surface actionable build issues to contributors.

```yaml
- uses: arduino/compile-sketches@...
  with:
    enable-issues-report: true
```

**Default:** `false`

---

### New input: `fail-on-build-error`

A new boolean input that, when disabled, causes the action to always return a success exit code regardless of whether any sketch compilations failed.

This is useful in scenarios where you want to collect compilation data and produce a report without failing the entire workflow — for example, when the compilation status is a comment rather than a blocking check. In the ArduinoCore-zephyr repo this is used to monitor the state of known issues (builds that _should_ work but are known to fail with the latest code). 

```yaml
- uses: arduino/compile-sketches@...
  with:
    fail-on-build-error: false
```

**Default:** `true`

---

### Improved compilation error messages

The error message printed to the GitHub Actions log when a sketch fails to compile now includes the sketch path/name, making it easier to identify the failing sketch directly in the workflow run summary. This is very useful when used with `always-succeed` and a number of failing builds are present.

**Before:**
```
::error::Compilation failed
```

**After:**
```
::error::Compilation failed: path/to/MySketch/MySketch.ino
```

---

### Commit hash read from GitHub event payload

The action previously used `git rev-parse HEAD` to determine the commit hash for the sketches report in all cases, with the exception of pull-request events (where the actual source commit SHA was taken directly from the GitHub event payload). This change adds a similar exception for branch push events as well.

This allows the action to report the correct commit hash even in workflows where the full Git repository is not available — for example (as in the case of ArduinoCore-zephyr) when the sources being compiled come from an artifact.