### PR TITLE
Exclude HTTP status code 429 from link check

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -9,5 +9,5 @@
   ],
   "retryOn429": true,
   "retryCount": 3,
-  "aliveStatusCodes": [200, 206]
+  "aliveStatusCodes": [200, 206, 429]
 }


### PR DESCRIPTION
Links in the documentation files are validated using the markdown-link-check tool.

Unfortunately links to Arduino forum pages now return 429 status codes to the link checker tool. This caused the link check to fail spuriously. Spurious failures are is problematic, both because it will result in a poor experience for contributors, and because it causes the project maintainers to disregard failed checks, and thus possibly miss true positive detections.

The spurious failures are avoided by configure the link checker tool to consider links that return a 429 status code to be functional. This is not ideal, but is the only available resolution.